### PR TITLE
Revert "Ioda UI#82"

### DIFF
--- a/assets/js/Ioda/components/modal/Modal.js
+++ b/assets/js/Ioda/components/modal/Modal.js
@@ -28,13 +28,6 @@ class Modal extends Component {
         const bgpHtsLabel = T.translate("entityModal.bgpHtsLabel");
         const ucsdNtHtsLabel = T.translate("entityModal.ucsdNtHtsLabel");
 
-        const displayCountShowing = T.translate("table.displayCountShowing");
-        const displayCountOf = T.translate("table.displayCountOf");
-        const displayCountEntries = T.translate("table.displayCountEntries");
-        const prevButtonText = T.translate("table.prevButtonText");
-        const nextButtonText = T.translate("table.nextButtonText");
-
-        console.log(this.props);
         return(
             <div className="modal">
                 <div className="modal__background"></div>
@@ -91,13 +84,6 @@ class Modal extends Component {
                                                 this.props.populateRegionalHtsChart(this.configUcsdNt.current.offsetWidth, 'ucsd-nt') : null
                                             }
                                         </div>
-                                        <div className="table__page">
-                                            <p className="table__page-text">{displayCountShowing} {this.props.rawRegionalSignalsHtsCurrentDisplayLow + 1} - {this.props.rawRegionalSignalsHtsCurrentDisplayHigh} {displayCountOf} {this.props.rawRegionalSignalsHtsTotalCount} {displayCountEntries}</p>
-                                            <div className="table__page-controls">
-                                                <button onClick={() => this.props.prevPageRawRegionalSignalsHts()} className="table__page-button">{prevButtonText}</button>
-                                                <button onClick={() => this.props.nextPageRawRegionalSignalsHts()} className="table__page-button">{nextButtonText}</button>
-                                            </div>
-                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -136,13 +122,6 @@ class Modal extends Component {
                                                 this.configUcsdNt.current ?
                                                 this.props.populateAsnHtsChart(this.configUcsdNt.current.offsetWidth, 'ucsd-nt') : null
                                             }
-                                        </div>
-                                        <div className="table__page">
-                                            <p className="table__page-text">{displayCountShowing} {this.props.rawAsnSignalsHtsCurrentDisplayLow + 1} - {this.props.rawAsnSignalsHtsCurrentDisplayHigh} {displayCountOf} {this.props.rawAsnSignalsHtsTotalCount} {displayCountEntries}</p>
-                                            <div className="table__page-controls">
-                                                <button onClick={() => this.props.prevPageRawAsnSignalsHts()} className="table__page-button">{prevButtonText}</button>
-                                                <button onClick={() => this.props.nextPageRawAsnSignalsHts()} className="table__page-button">{nextButtonText}</button>
-                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/assets/js/Ioda/pages/dashboard/Dashboard.js
+++ b/assets/js/Ioda/pages/dashboard/Dashboard.js
@@ -82,9 +82,10 @@ class Dashboard extends Component {
             region: region.tab,
             as: as.tab
         };
-        this.countryTab = T.translate("dashboard.countryTabTitle");
-        this.regionTab = T.translate("dashboard.regionTabTitle");
-        this.asTab = T.translate("dashboard.asnTabTitle");
+        // ToDo: Add to internationalization
+        this.countryTab = "Country View";
+        this.regionTab = "Region View";
+        this.asTab = "AS/ISP View";
         this.handleTimeFrame = this.handleTimeFrame.bind(this);
         this.apiQueryLimit = 170;
     }

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -110,22 +110,15 @@ class Entity extends Component {
             rawRegionalSignalsProcessedBgp: [],
             rawRegionalSignalsProcessedPingSlash24: [],
             rawRegionalSignalsProcessedUcsdNt: [],
-            rawRegionalSignalsHtsPageNumber: 0,
-            rawRegionalSignalsHtsCurrentDisplayLow: 0,
-            rawRegionalSignalsHtsCurrentDisplayHigh: 10,
             // Stacked Horizon Visual on ASN Table Panel
             rawAsnSignals: [],
             rawAsnSignalsProcessedBgp: [],
             rawAsnSignalsProcessedPingSlash24: [],
             rawAsnSignalsProcessedUcsdNt: [],
-            rawAsnSignalsHtsPageNumber: 0,
-            rawAsnSignalsHtsCurrentDisplayLow: 0,
-            rawAsnSignalsHtsCurrentDisplayHigh: 10,
         };
         this.handleTimeFrame = this.handleTimeFrame.bind(this);
         this.toggleModal = this.toggleModal.bind(this);
         this.apiQueryLimit = 170;
-        this.rawSignalsHtsLimit = 10;
     }
 
     componentDidMount() {
@@ -768,18 +761,6 @@ class Entity extends Component {
             genAsnSignalsTable={() => this.genAsnSignalsTable()}
             populateRegionalHtsChart={(width, datasource) => this.populateRegionalHtsChart(width, datasource)}
             populateAsnHtsChart={(width, datasource) => this.populateAsnHtsChart(width, datasource)}
-            // regional modal hts pagination props
-            prevPageRawRegionalSignalsHts={() => this.prevPageRawRegionalSignalsHts()}
-            nextPageRawRegionalSignalsHts={() => this.nextPageRawRegionalSignalsHts()}
-            rawRegionalSignalsHtsCurrentDisplayLow={this.state.rawRegionalSignalsHtsCurrentDisplayLow}
-            rawRegionalSignalsHtsCurrentDisplayHigh={this.state.rawRegionalSignalsHtsCurrentDisplayHigh}
-            rawRegionalSignalsHtsTotalCount={this.state.regionalSignalsTableSummaryDataProcessed.length}
-            // asn modal hts pagination props
-            prevPageRawAsnSignalsHts={() => this.prevPageRawAsnSignalsHts()}
-            nextPageRawAsnSignalsHts={() => this.nextPageRawAsnSignalsHts()}
-            rawAsnSignalsHtsCurrentDisplayLow={this.state.rawAsnSignalsHtsCurrentDisplayLow}
-            rawAsnSignalsHtsCurrentDisplayHigh={this.state.rawAsnSignalsHtsCurrentDisplayHigh}
-            rawAsnSignalsHtsTotalCount={this.state.asnSignalsTableSummaryDataProcessed.length}
         />;
     }
     // Show/hide modal when button is clicked on either panel
@@ -1145,15 +1126,12 @@ class Entity extends Component {
         let from = this.state.from;
         let attr = this.state.eventOrderByAttr;
         let order = this.state.eventOrderByOrder;
-        let entities = this.state.regionalSignalsTableSummaryDataProcessed.slice(
-            this.state.rawRegionalSignalsHtsCurrentDisplayLow,
-            this.state.rawRegionalSignalsHtsCurrentDisplayHigh
-        ).map(entity => {
-                // some entities don't return a code to be used in an api call, seem to default to '??' in that event
-                if (entity.code !== "??") {
-                    return entity.entityCode;
-                }
-            }).toString();
+        let entities = this.state.regionalSignalsTableSummaryDataProcessed.slice(0, 10).map(entity => {
+            // some entities don't return a code to be used in an api call, seem to default to '??' in that event
+            if (entity.code !== "??") {
+                return entity.entityCode;
+            }
+        }).toString();
         this.props.getRawRegionalSignalsAction(entityType, entities, from, until, attr, order);
     }
     convertValuesForRegionalHtsViz() {
@@ -1256,36 +1234,6 @@ class Entity extends Component {
         }
     }
 
-    // pagination on regional Horizon Time Series charts
-    nextPageRawRegionalSignalsHts() {
-        let nextPageValues = nextPage(!!this.state.regionalSignalsTableSummaryDataProcessed, this.state.regionalSignalsTableSummaryDataProcessed.length, this.state.rawRegionalSignalsHtsPageNumber, this.state.rawRegionalSignalsHtsCurrentDisplayHigh, this.state.rawRegionalSignalsHtsCurrentDisplayLow);
-        this.setState({
-            rawRegionalSignalsHtsPageNumber: nextPageValues.newPageNumber,
-            rawRegionalSignalsHtsCurrentDisplayLow: nextPageValues.newCurrentDisplayLow,
-            rawRegionalSignalsHtsCurrentDisplayHigh: nextPageValues.newCurrentDisplayHigh,
-            rawRegionalSignals: [],
-            rawRegionalSignalsProcessedBgp: [],
-            rawRegionalSignalsProcessedPingSlash24: [],
-            rawRegionalSignalsProcessedUcsdNt: []
-        }, () => {
-            this.getRegionalSignalsHtsDataEvents("region");
-        });
-    }
-    prevPageRawRegionalSignalsHts() {
-        let prevPageValues = prevPage(!!this.state.regionalSignalsTableSummaryDataProcessed, this.state.regionalSignalsTableSummaryDataProcessed.length, this.state.rawRegionalSignalsHtsPageNumber, this.state.rawRegionalSignalsHtsCurrentDisplayHigh, this.state.rawRegionalSignalsHtsCurrentDisplayLow);
-        this.setState({
-            rawRegionalSignalsHtsPageNumber: prevPageValues.newPageNumber,
-            rawRegionalSignalsHtsCurrentDisplayLow: prevPageValues.newCurrentDisplayLow,
-            rawRegionalSignalsHtsCurrentDisplayHigh: prevPageValues.newCurrentDisplayHigh,
-            rawRegionalSignals: [],
-            rawRegionalSignalsProcessedBgp: [],
-            rawRegionalSignalsProcessedPingSlash24: [],
-            rawRegionalSignalsProcessedUcsdNt: []
-        }, () => {
-            this.getRegionalSignalsHtsDataEvents("region");
-        });
-    }
-
 
 // Table Modal
     // Table displaying all ASes regardless of score
@@ -1386,10 +1334,7 @@ class Entity extends Component {
         let from = this.state.from;
         let attr = this.state.eventOrderByAttr;
         let order = this.state.eventOrderByOrder;
-        let entities = this.state.asnSignalsTableSummaryDataProcessed.slice(
-            this.state.rawAsnSignalsHtsCurrentDisplayLow,
-            this.state.rawAsnSignalsHtsCurrentDisplayHigh
-        ).map(entity => {
+        let entities = this.state.asnSignalsTableSummaryDataProcessed.slice(0, 30).map(entity => {
             // some entities don't return a code to be used in an api call, seem to default to '??' in that event
             if (entity.code !== "??") {
                 return entity.entityCode;
@@ -1497,36 +1442,6 @@ class Entity extends Component {
             default:
                 break;
         }
-    }
-    // pagination on regional Horizon Time Series charts
-    nextPageRawAsnSignalsHts() {
-        console.log("here");
-        let nextPageValues = nextPage(!!this.state.asnSignalsTableSummaryDataProcessed, this.state.asnSignalsTableSummaryDataProcessed.length, this.state.rawAsnSignalsHtsPageNumber, this.state.rawAsnSignalsHtsCurrentDisplayHigh, this.state.rawAsnSignalsHtsCurrentDisplayLow);
-        this.setState({
-            rawAsnSignalsHtsPageNumber: nextPageValues.newPageNumber,
-            rawAsnSignalsHtsCurrentDisplayLow: nextPageValues.newCurrentDisplayLow,
-            rawAsnSignalsHtsCurrentDisplayHigh: nextPageValues.newCurrentDisplayHigh,
-            rawAsnSignals: [],
-            rawAsnSignalsProcessedBgp: [],
-            rawAsnSignalsProcessedPingSlash24: [],
-            rawAsnSignalsProcessedUcsdNt: []
-        }, () => {
-            this.getAsnSignalsHtsDataEvents("asn");
-        });
-    }
-    prevPageRawAsnSignalsHts() {
-        let prevPageValues = prevPage(!!this.state.regionalSignalsTableSummaryDataProcessed, this.state.regionalSignalsTableSummaryDataProcessed.length, this.state.rawRegionalSignalsHtsPageNumber, this.state.rawRegionalSignalsHtsCurrentDisplayHigh, this.state.rawRegionalSignalsHtsCurrentDisplayLow);
-        this.setState({
-            rawRegionalSignalsHtsPageNumber: prevPageValues.newPageNumber,
-            rawRegionalSignalsHtsCurrentDisplayLow: prevPageValues.newCurrentDisplayLow,
-            rawRegionalSignalsHtsCurrentDisplayHigh: prevPageValues.newCurrentDisplayHigh,
-            rawRegionalSignals: [],
-            rawRegionalSignalsProcessedBgp: [],
-            rawRegionalSignalsProcessedPingSlash24: [],
-            rawRegionalSignalsProcessedUcsdNt: []
-        }, () => {
-            this.getRegionalSignalsHtsDataEvents("region");
-        });
     }
 
     render() {

--- a/assets/js/Ioda/pages/entity/EntityRelated.js
+++ b/assets/js/Ioda/pages/entity/EntityRelated.js
@@ -42,12 +42,6 @@ class EntityRelated extends Component {
                                 populateGeoJsonMap={() => this.props.populateGeoJsonMap()}
                                 genRegionalSignalsTable={this.props.genRegionalSignalsTable}
                                 populateRegionalHtsChart={(width, datasource) => this.props.populateRegionalHtsChart(width, datasource)}
-                                // regional modal hts pagination props
-                                prevPageRawRegionalSignalsHts={() => this.props.prevPageRawRegionalSignalsHts()}
-                                nextPageRawRegionalSignalsHts={() => this.props.nextPageRawRegionalSignalsHts()}
-                                rawRegionalSignalsHtsCurrentDisplayLow={this.props.rawRegionalSignalsHtsCurrentDisplayLow}
-                                rawRegionalSignalsHtsCurrentDisplayHigh={this.props.rawRegionalSignalsHtsCurrentDisplayHigh}
-                                rawRegionalSignalsHtsTotalCount={this.props.rawRegionalSignalsHtsTotalCount}
                             />
                         </div>
                     </div>
@@ -83,12 +77,6 @@ class EntityRelated extends Component {
                                 toggleModal={this.props.toggleModal}
                                 genSignalsTable={() => this.props.genAsnSignalsTable()}
                                 populateAsnHtsChart={(width, datasource) => this.props.populateAsnHtsChart(width, datasource)}
-                                // asn modal hts pagination props
-                                prevPageRawAsnSignalsHts={() => this.props.prevPageRawAsnSignalsHts()}
-                                nextPageRawAsnSignalsHts={() => this.props.nextPageRawAsnSignalsHts()}
-                                rawAsnSignalsHtsCurrentDisplayLow={this.props.rawAsnSignalsHtsCurrentDisplayLow}
-                                rawAsnSignalsHtsCurrentDisplayHigh={this.props.rawAsnSignalsHtsCurrentDisplayHigh}
-                                rawAsnSignalsHtsTotalCount={this.props.rawAsnSignalsHtsTotalCount}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
Reverts CAIDA/ioda-ui#132

We want the visual to load all datasources instead of paginating in any way. Then leave it up to the api to resolve the delay issue. 