### PR TITLE
carry timestamp over when clicking an entity from a table, if available

### DIFF
--- a/assets/js/Ioda/components/table/SignalTableRow.js
+++ b/assets/js/Ioda/components/table/SignalTableRow.js
@@ -96,7 +96,14 @@ class SignalTableRow extends Component {
                         : null
                 }
                 <td>
-                    <Link className="table__cell-link" to={`/${this.props.data.entityType}/${this.props.data.entityCode}`} onClick={() => this.props.handleEntityClick()}>
+                    <Link className="table__cell-link"
+                          to={
+                              window.location.search.split("?")[1]
+                                  ? `/${this.props.data.entityType}/${this.props.data.entityCode}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                                  : `/${this.props.data.entityType}/${this.props.data.entityCode}`
+                          }
+                          onClick={() => this.props.handleEntityClick()}
+                    >
                         {this.props.data.name}
                     </Link>
                 </td>

--- a/assets/js/Ioda/components/table/SummaryTableRow.js
+++ b/assets/js/Ioda/components/table/SummaryTableRow.js
@@ -95,7 +95,14 @@ class SummaryTableRow extends Component {
                     : null
                 }
                 <td>
-                    <Link className="table__cell-link" to={`/${this.props.data.entityType}/${this.props.data.entityCode}`} onClick={() => this.props.handleEntityClick()}>
+                    <Link className="table__cell-link"
+                          to={
+                              window.location.search.split("?")[1]
+                                  ? `/${this.props.data.entityType}/${this.props.data.entityCode}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                                  : `/${this.props.data.entityType}/${this.props.data.entityCode}`
+                          }
+                          onClick={() => this.props.handleEntityClick()}
+                    >
                         {this.props.data.name}
                     </Link>
                 </td>


### PR DESCRIPTION
Resolves #162. 