### PR TITLE
Ioda UI#155

### DIFF
--- a/assets/js/Ioda/components/modal/Modal.js
+++ b/assets/js/Ioda/components/modal/Modal.js
@@ -69,6 +69,12 @@ class Modal extends Component {
                                 <div className="row">
                                     <div className="col-1-of-3">
                                         <h3 className="heading-h3">{regionalTableTitle}</h3>
+                                        <button className="modal__button--table" name="checkMaxRegional" onClick={event => this.props.handleSelectAndDeselectAllButtons(event)}>
+                                            Check Max
+                                        </button>
+                                        <button className="modal__button--table" name="uncheckAllRegional" onClick={event => this.props.handleSelectAndDeselectAllButtons(event)}>
+                                            Uncheck All
+                                        </button>
                                         <div className="modal__table">
                                             {
                                                 this.props.regionalSignalsTableSummaryDataProcessed.length ?
@@ -87,6 +93,7 @@ class Modal extends Component {
                                         </div>
                                     </div>
                                     <div className="col-2-of-3">
+                                        <p>Displaying {this.props.regionalSignalsTableEntitiesChecked} Regions - Use checkboxes on the Regional Raw Signals table to change the selection.</p>
                                         <h3 className="heading-h3">{pingSlash24HtsLabel}</h3>
                                         {
                                             this.props.rawRegionalSignalsProcessedPingSlash24.length === 0 ? <Loading/> : null
@@ -129,6 +136,12 @@ class Modal extends Component {
                                 <div className="row">
                                     <div className="col-1-of-3">
                                         <h3 className="heading-h3">{asnTableTitle}</h3>
+                                        <button className="modal__button--table" name="checkMaxAsn" onClick={event => this.props.handleSelectAndDeselectAllButtons(event)}>
+                                            Check Max
+                                        </button>
+                                        <button className="modal__button--table" name="uncheckAllAsn" onClick={event => this.props.handleSelectAndDeselectAllButtons(event)}>
+                                            Uncheck All
+                                        </button>
                                         <div className="modal__table">
                                             {
                                                 this.props.asnSignalsTableSummaryDataProcessed.length ?
@@ -137,6 +150,7 @@ class Modal extends Component {
                                         </div>
                                     </div>
                                     <div className="col-2-of-3">
+                                        <p>Displaying {this.props.asnSignalsTableEntitiesChecked} ASNs/ISPs - Use checkboxes on the ASN/ISP Raw Signals table to change the selection.</p>
                                         <h3 className="heading-h3">{pingSlash24HtsLabel}</h3>
                                         {
                                             this.props.rawAsnSignalsProcessedPingSlash24.length === 0 ? <Loading/> : null

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -1319,9 +1319,6 @@ class Entity extends Component {
     toggleEntityVisibilityInAsnHtsViz(event) {
         let indexValue;
         let asnSignalsTableSummaryDataProcessed = this.state.asnSignalsTableSummaryDataProcessed;
-        let rawAsnSignals = this.props.rawAsnSignals;
-
-        let visibilityFalseEntities = [];
 
         // Get the index of where the checkmark was that was clicked
         asnSignalsTableSummaryDataProcessed.filter((entity, index) => {
@@ -1330,29 +1327,10 @@ class Entity extends Component {
             }
         });
         // Update visibility boolean property in copied object to update table
-       asnSignalsTableSummaryDataProcessed[indexValue]["visibility"] = !asnSignalsTableSummaryDataProcessed[indexValue]["visibility"];
+        asnSignalsTableSummaryDataProcessed[indexValue]["visibility"] = !asnSignalsTableSummaryDataProcessed[indexValue]["visibility"];
 
-        // Group IDs for items that have visibility set to false, remove items from group that are now set to true
-        asnSignalsTableSummaryDataProcessed.map((asnSignalsTableEntity, index) => {
-            if (asnSignalsTableEntity.visibility === false || !asnSignalsTableEntity.visibility) {
-                visibilityFalseEntities.push(asnSignalsTableEntity.entityCode);
-            } else {
-                visibilityFalseEntities.splice(index, index + 1);
-            }
-        });
-
-        // Update rawRegionalSignals state removing selected items with visibility set to false in regionalSignalsTableSummaryDataProcessed
-        if (visibilityFalseEntities.length > 0) {
-            visibilityFalseEntities.map(entityCode => {
-                rawAsnSignals = rawAsnSignals.filter(asnSignal => asnSignal[0].entityCode !== entityCode)
-            }, this);
-        } else {
-            rawAsnSignals = this.props.rawAsnSignals;
-        }
-
-        // Update new state with visibility checked and new hts data that reflects that, then redraw the chart
+        // Update state with freshly updated object list, then redraw the chart with new visibility values
         this.setState({
-            rawAsnSignals: rawAsnSignals,
             asnSignalsTableSummaryDataProcessed: asnSignalsTableSummaryDataProcessed
         }, () => {
             this.convertValuesForAsnHtsViz("ping-slash24");
@@ -1441,7 +1419,6 @@ class Entity extends Component {
                 });
                 break;
         }
-
     }
     populateAsnHtsChartPingSlash24(width) {
         if (this.state.rawAsnSignalsProcessedPingSlash24.length && this.state.rawAsnSignalsLoadedPingSlash24) {

--- a/assets/js/Ioda/pages/entity/EntityRelated.js
+++ b/assets/js/Ioda/pages/entity/EntityRelated.js
@@ -42,6 +42,8 @@ class EntityRelated extends Component {
                                 toggleModal={this.props.toggleModal}
                                 populateGeoJsonMap={() => this.props.populateGeoJsonMap()}
                                 genRegionalSignalsTable={this.props.genRegionalSignalsTable}
+                                handleSelectAndDeselectAllButtons={(event) => this.props.handleSelectAndDeselectAllButtons(event)}
+                                regionalSignalsTableEntitiesChecked={this.props.regionalSignalsTableEntitiesChecked}
                                 // populateRegionalHtsChart={(width, datasource) => this.props.populateRegionalHtsChart(width, datasource)}
                                 populateRegionalHtsChartPingSlash24={(width) => this.props.populateRegionalHtsChartPingSlash24(width)}
                                 populateRegionalHtsChartBgp={(width) => this.props.populateRegionalHtsChartBgp(width)}
@@ -86,6 +88,7 @@ class EntityRelated extends Component {
                                 showModal={this.props.showTableModal}
                                 toggleModal={this.props.toggleModal}
                                 genSignalsTable={() => this.props.genAsnSignalsTable()}
+                                handleSelectAndDeselectAllButtons={(event) => this.props.handleSelectAndDeselectAllButtons(event)}
                                 populateAsnHtsChartPingSlash24={(width) => this.props.populateAsnHtsChartPingSlash24(width)}
                                 populateAsnHtsChartBgp={(width) => this.props.populateAsnHtsChartBgp(width)}
                                 populateAsnHtsChartUcsdNt={(width) => this.props.populateAsnHtsChartUcsdNt(width)}
@@ -93,6 +96,7 @@ class EntityRelated extends Component {
                                 rawAsnSignalsProcessedBgp={this.props.rawAsnSignalsProcessedBgp}
                                 rawAsnSignalsProcessedUcsdNt={this.props.rawAsnSignalsProcessedUcsdNt}
                                 asnSignalsTableSummaryDataProcessed={this.props.asnSignalsTableSummaryDataProcessed}
+                                asnSignalsTableEntitiesChecked={this.props.asnSignalsTableEntitiesChecked}
                             />
                         </div>
                     </div>

--- a/assets/js/Ioda/utils/index.js
+++ b/assets/js/Ioda/utils/index.js
@@ -149,10 +149,11 @@ export function convertValuesForSummaryTable(summaryDataRaw) {
     return summaryData;
 }
 
-export function combineValuesForSignalsTable(entitiesWithOutages, additionalEntities) {
+export function combineValuesForSignalsTable(entitiesWithOutages, additionalEntities, initialLimit) {
     let summaryData = [];
+    let outageCount = 0;
     let duplicatesRemoved = additionalEntities;
-    entitiesWithOutages.map(entity => {
+    entitiesWithOutages.map((entity, index) => {
         let overallScore = null;
         let summaryScores = [];
         // Get each score value for score table
@@ -174,7 +175,7 @@ export function combineValuesForSignalsTable(entitiesWithOutages, additionalEnti
         let summaryItem;
         entity.entity.type === 'asn'
             ? summaryItem = {
-                visibility: true,
+                visibility: index < initialLimit,
                 entityType: entity["entity"].type,
                 entityCode: entity["entity"].code,
                 name: entity["entity"].name,
@@ -183,7 +184,7 @@ export function combineValuesForSignalsTable(entitiesWithOutages, additionalEnti
                 ipCount: humanizeNumber(entity["entity"]["attrs"]["ip_count"], 2)
             }
             : summaryItem = {
-                visibility: true,
+                visibility: index < initialLimit,
                 entityType: entity["entity"].type,
                 entityCode: entity["entity"].code,
                 name: entity["entity"].name,
@@ -192,13 +193,14 @@ export function combineValuesForSignalsTable(entitiesWithOutages, additionalEnti
             };
         summaryData.push(summaryItem);
     });
+    outageCount = summaryData.length;
 
     // Display scoreless entities on signal table, if asn add ip count property
-    duplicatesRemoved.map(entity => {
+    duplicatesRemoved.map((entity, index) => {
         let entityItem;
         entity.type === 'asn'
             ? entityItem = {
-                visibility: true,
+                visibility: index < initialLimit - outageCount,
                 entityType: entity.type,
                 entityCode: entity.code,
                 name: entity.name,
@@ -207,7 +209,7 @@ export function combineValuesForSignalsTable(entitiesWithOutages, additionalEnti
                 ipCount: humanizeNumber(entity.attrs.ip_count, 2)
             }
             : entityItem = {
-                visibility: true,
+                visibility: index < initialLimit - outageCount,
                 entityType: entity.type,
                 entityCode: entity.code,
                 name: entity.name,


### PR DESCRIPTION
Partially resolves issue #155 - Add ability to toggle raw signal entities visibility, set initial load limits, add ability to check/uncheck all. 

Table now only loads 300 entities, but displays total count.
horizon time series now only displays 100 entities initially, with the ability to toggle visibility from the table.
buttons that uncheck all, check max amount (150) and update the viz accordingly.
Display current count of entities visible in the raw signals horizon times series.

ToDo which will be broken down into separate issues: 
- Add cap to amount of entities that load in horizon time series.
- Bug where when clicking all entities off will not update the visual correctly, need to link visual display vs loading bar to something other than number of entities currently displayed in visual.

