### PR TITLE
 #191 - No entities checked will not update the visual correctly

### DIFF
--- a/assets/js/Ioda/components/modal/Modal.js
+++ b/assets/js/Ioda/components/modal/Modal.js
@@ -116,7 +116,7 @@ class Modal extends Component {
                                         </p>
                                         <h3 className="heading-h3">{pingSlash24HtsLabel}</h3>
                                         {
-                                            this.props.rawRegionalSignalsProcessedPingSlash24.length === 0 ? <Loading/> : null
+                                            this.props.rawRegionalSignalsProcessedPingSlash24 ? null : <Loading/>
                                         }
                                         <div id="regional-horizon-chart--pingSlash24" ref={this.configPingSlash24} className="modal__chart">
                                             {
@@ -127,7 +127,7 @@ class Modal extends Component {
 
                                         <h3 className="heading-h3">{bgpHtsLabel}</h3>
                                         {
-                                            this.props.rawRegionalSignalsProcessedBgp.length === 0 ? <Loading/> : null
+                                            this.props.rawRegionalSignalsProcessedBgp ? null : <Loading/>
                                         }
                                         <div id="regional-horizon-chart--bgp" ref={this.configBgp} className="modal__chart">
                                             {
@@ -137,7 +137,7 @@ class Modal extends Component {
                                         </div>
                                         <h3 className="heading-h3">{ucsdNtHtsLabel}</h3>
                                         {
-                                            this.props.rawRegionalSignalsProcessedUcsdNt.length === 0 ? <Loading/> : null
+                                            this.props.rawRegionalSignalsProcessedUcsdNt ? null : <Loading/>
                                         }
                                         <div id="regional-horizon-chart--ucsdNt" ref={this.configUcsdNt} className="modal__chart">
                                             {
@@ -173,7 +173,6 @@ class Modal extends Component {
                                         </div>
                                     </div>
                                     <div className="col-2-of-3">
-
                                         <p className="modal__hts-count">
                                             {currentCountInHts1}
                                             {this.props.asnSignalsTableEntitiesChecked}
@@ -185,7 +184,7 @@ class Modal extends Component {
 
                                         <h3 className="heading-h3">{pingSlash24HtsLabel}</h3>
                                         {
-                                            this.props.rawAsnSignalsProcessedPingSlash24.length === 0 ? <Loading/> : null
+                                            this.props.rawAsnSignalsProcessedPingSlash24 ? null : <Loading/>
                                         }
                                         <div id="asn-horizon-chart--pingSlash24" ref={this.configPingSlash24} className="modal__chart">
                                             {
@@ -195,7 +194,7 @@ class Modal extends Component {
                                         </div>
                                         <h3 className="heading-h3">{bgpHtsLabel}</h3>
                                         {
-                                            this.props.rawAsnSignalsProcessedBgp.length === 0 ? <Loading/> : null
+                                            this.props.rawAsnSignalsProcessedBgp ? null : <Loading/>
                                         }
                                         <div id="asn-horizon-chart--bgp" ref={this.configBgp} className="modal__chart">
                                             {
@@ -205,7 +204,7 @@ class Modal extends Component {
                                         </div>
                                         <h3 className="heading-h3">{ucsdNtHtsLabel}</h3>
                                         {
-                                            this.props.rawAsnSignalsProcessedUcsdNt.length === 0 ? <Loading/> : null
+                                            this.props.rawAsnSignalsProcessedUcsdNt ? null : <Loading/>
                                         }
                                         <div id="asn-horizon-chart--ucsdNt" ref={this.configUcsdNt} className="modal__chart">
                                             {

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -101,9 +101,9 @@ class Entity extends Component {
             rawRegionalSignalsRawBgp: [],
             rawRegionalSignalsRawPingSlash24: [],
             rawRegionalSignalsRawUcsdNt: [],
-            rawRegionalSignalsProcessedBgp: [],
-            rawRegionalSignalsProcessedPingSlash24: [],
-            rawRegionalSignalsProcessedUcsdNt: [],
+            rawRegionalSignalsProcessedBgp: null,
+            rawRegionalSignalsProcessedPingSlash24: null,
+            rawRegionalSignalsProcessedUcsdNt: null,
             rawRegionalSignalsLoadedBgp: true,
             rawRegionalSignalsLoadedPingSlash24: true,
             rawRegionalSignalsLoadedUcsdNt: true,
@@ -111,9 +111,9 @@ class Entity extends Component {
             rawAsnSignalsRawBgp: [],
             rawAsnSignalsRawPingSlash24: [],
             rawAsnSignalsRawUcsdNt: [],
-            rawAsnSignalsProcessedBgp: [],
-            rawAsnSignalsProcessedPingSlash24: [],
-            rawAsnSignalsProcessedUcsdNt: [],
+            rawAsnSignalsProcessedBgp: null,
+            rawAsnSignalsProcessedPingSlash24: null,
+            rawAsnSignalsProcessedUcsdNt: null,
             rawAsnSignalsLoadedBgp: true,
             rawAsnSignalsLoadedPingSlash24: true,
             rawAsnSignalsLoadedUcsdNt: true,
@@ -382,16 +382,16 @@ class Entity extends Component {
             rawRegionalSignalsRawBgp: [],
             rawRegionalSignalsRawPingSlash24: [],
             rawRegionalSignalsRawUcsdNt: [],
-            rawRegionalSignalsProcessedBgp: [],
-            rawRegionalSignalsProcessedPingSlash24: [],
-            rawRegionalSignalsProcessedUcsdNt: [],
+            rawRegionalSignalsProcessedBgp: null,
+            rawRegionalSignalsProcessedPingSlash24: null,
+            rawRegionalSignalsProcessedUcsdNt: null,
             // Stacked Horizon Visual on ASN Table Panel
             rawAsnSignalsRawBgp: [],
             rawAsnSignalsRawPingSlash24: [],
             rawAsnSignalsRawUcsdNt: [],
-            rawAsnSignalsProcessedBgp: [],
-            rawAsnSignalsProcessedPingSlash24: [],
-            rawAsnSignalsProcessedUcsdNt: [],
+            rawAsnSignalsProcessedBgp: null,
+            rawAsnSignalsProcessedPingSlash24: null,
+            rawAsnSignalsProcessedUcsdNt: null,
         }, () => {
             // Get topo and outage data to repopulate map and table
             this.props.searchEventsAction(this.state.from, this.state.until, this.state.entityType, this.state.entityCode);
@@ -472,16 +472,16 @@ class Entity extends Component {
             rawRegionalSignalsRawBgp: [],
             rawRegionalSignalsRawPingSlash24: [],
             rawRegionalSignalsRawUcsdNt: [],
-            rawRegionalSignalsProcessedBgp: [],
-            rawRegionalSignalsProcessedPingSlash24: [],
-            rawRegionalSignalsProcessedUcsdNt: [],
+            rawRegionalSignalsProcessedBgp: null,
+            rawRegionalSignalsProcessedPingSlash24: null,
+            rawRegionalSignalsProcessedUcsdNt: null,
             // Stacked Horizon Visual on ASN Table Panel
             rawAsnSignalsRawBgp: [],
             rawAsnSignalsRawPingSlash24: [],
             rawAsnSignalsRawUcsdNt: [],
-            rawAsnSignalsProcessedBgp: [],
-            rawAsnSignalsProcessedPingSlash24: [],
-            rawAsnSignalsProcessedUcsdNt: [],
+            rawAsnSignalsProcessedBgp: null,
+            rawAsnSignalsProcessedPingSlash24: null,
+            rawAsnSignalsProcessedUcsdNt: null,
             rawAsnSignalsLoadedBgp: true,
             rawAsnSignalsLoadedPingSlash24: true,
             rawAsnSignalsLoadedUcsdNt: true,
@@ -1088,16 +1088,16 @@ class Entity extends Component {
             rawRegionalSignalsRawBgp: [],
             rawRegionalSignalsRawPingSlash24: [],
             rawRegionalSignalsRawUcsdNt: [],
-            rawRegionalSignalsProcessedBgp: [],
-            rawRegionalSignalsProcessedPingSlash24: [],
-            rawRegionalSignalsProcessedUcsdNt: [],
+            rawRegionalSignalsProcessedBgp: null,
+            rawRegionalSignalsProcessedPingSlash24: null,
+            rawRegionalSignalsProcessedUcsdNt: null,
             // Stacked Horizon Visual on ASN Table Panel
             rawAsnSignalsRawBgp: [],
             rawAsnSignalsRawPingSlash24: [],
             rawAsnSignalsRawUcsdNt: [],
-            rawAsnSignalsProcessedBgp: [],
-            rawAsnSignalsProcessedPingSlash24: [],
-            rawAsnSignalsProcessedUcsdNt: [],
+            rawAsnSignalsProcessedBgp: null,
+            rawAsnSignalsProcessedPingSlash24: null,
+            rawAsnSignalsProcessedUcsdNt: null,
             rawAsnSignalsLoadedBgp: true,
             rawAsnSignalsLoadedPingSlash24: true,
             rawAsnSignalsLoadedUcsdNt: true,
@@ -1119,12 +1119,9 @@ class Entity extends Component {
                 regionalSignalsTableTotalCount: signalsTableData.length
             }, () => {
                 // Get data for Stacked horizon series raw signals with all regions if data is not yet available
-                this.state.rawRegionalSignalsProcessedPingSlash24.length === 0 ?
-                    this.getRegionalSignalsHtsDataEvents("region", "ping-slash24") : null;
-                this.state.rawAsnSignalsProcessedBgp.length === 0 ?
-                    this.getRegionalSignalsHtsDataEvents("region", "bgp") : null;
-                this.state.rawAsnSignalsProcessedUcsdNt.length === 0 ?
-                    this.getRegionalSignalsHtsDataEvents("region", "ucsd-nt") : null;
+                this.getRegionalSignalsHtsDataEvents("region", "ping-slash24");
+                this.getRegionalSignalsHtsDataEvents("region", "bgp");
+                this.getRegionalSignalsHtsDataEvents("region", "ucsd-nt");
             })
         }
     }
@@ -1252,7 +1249,7 @@ class Entity extends Component {
         }
     }
     populateRegionalHtsChartPingSlash24(width) {
-        if (this.state.rawRegionalSignalsProcessedPingSlash24.length && this.state.rawRegionalSignalsLoadedPingSlash24) {
+        if (this.state.rawRegionalSignalsProcessedPingSlash24 && this.state.rawRegionalSignalsLoadedPingSlash24) {
             this.setState({rawRegionalSignalsLoadedPingSlash24: !this.state.rawRegionalSignalsLoadedPingSlash24});
             const myChart = HorizonTSChart()(document.getElementById(`regional-horizon-chart--pingSlash24`));
             myChart
@@ -1273,7 +1270,7 @@ class Entity extends Component {
         }
     }
     populateRegionalHtsChartBgp(width) {
-        if (this.state.rawRegionalSignalsProcessedBgp.length && this.state.rawRegionalSignalsLoadedBgp) {
+        if (this.state.rawRegionalSignalsProcessedBgp && this.state.rawRegionalSignalsLoadedBgp) {
             this.setState({rawRegionalSignalsLoadedBgp: !this.state.rawRegionalSignalsLoadedBgp});
             const myChart = HorizonTSChart()(document.getElementById(`regional-horizon-chart--bgp`));
             myChart
@@ -1294,7 +1291,7 @@ class Entity extends Component {
         }
     }
     populateRegionalHtsChartUcsdNt(width) {
-        if (this.state.rawRegionalSignalsProcessedUcsdNt.length && this.state.rawRegionalSignalsLoadedUcsdNt) {
+        if (this.state.rawRegionalSignalsProcessedUcsdNt && this.state.rawRegionalSignalsLoadedUcsdNt) {
             this.setState({rawRegionalSignalsLoadedUcsdNt: !this.state.rawRegionalSignalsLoadedUcsdNt});
             const myChart = HorizonTSChart()(document.getElementById(`regional-horizon-chart--ucsdNt`));
             myChart
@@ -1355,7 +1352,7 @@ class Entity extends Component {
     toggleEntityVisibilityInAsnHtsViz(event) {
         let indexValue;
         let asnSignalsTableSummaryDataProcessed = this.state.asnSignalsTableSummaryDataProcessed;
-        let maxEntitiesPopulatedMessage = T.translate("entityModal.maxEntitiesPopulatedMessage")
+        let maxEntitiesPopulatedMessage = T.translate("entityModal.maxEntitiesPopulatedMessage");
 
 
         // Get the index of where the checkmark was that was clicked
@@ -1567,7 +1564,7 @@ class Entity extends Component {
         }
     }
     populateAsnHtsChartPingSlash24(width) {
-        if (this.state.rawAsnSignalsProcessedPingSlash24.length && this.state.rawAsnSignalsLoadedPingSlash24) {
+        if (this.state.rawAsnSignalsProcessedPingSlash24 && this.state.rawAsnSignalsLoadedPingSlash24) {
             this.setState({rawAsnSignalsLoadedPingSlash24: !this.state.rawAsnSignalsLoadedPingSlash24});
             const myChart = HorizonTSChart()(document.getElementById(`asn-horizon-chart--pingSlash24`));
             myChart
@@ -1588,7 +1585,7 @@ class Entity extends Component {
         }
     }
     populateAsnHtsChartBgp(width) {
-        if (this.state.rawAsnSignalsProcessedBgp.length && this.state.rawAsnSignalsLoadedBgp) {
+        if (this.state.rawAsnSignalsProcessedBgp && this.state.rawAsnSignalsLoadedBgp) {
             this.setState({rawAsnSignalsLoadedBgp: !this.state.rawAsnSignalsLoadedBgp});
             const myChart = HorizonTSChart()(document.getElementById(`asn-horizon-chart--bgp`));
             myChart
@@ -1609,7 +1606,7 @@ class Entity extends Component {
         }
     }
     populateAsnHtsChartUcsdNt(width) {
-        if (this.state.rawAsnSignalsProcessedUcsdNt.length && this.state.rawAsnSignalsLoadedUcsdNt) {
+        if (this.state.rawAsnSignalsProcessedUcsdNt && this.state.rawAsnSignalsLoadedUcsdNt) {
             this.setState({rawAsnSignalsLoadedUcsdNt: !this.state.rawAsnSignalsLoadedUcsdNt});
             const myChart = HorizonTSChart()(document.getElementById(`asn-horizon-chart--ucsdNt`));
             myChart


### PR DESCRIPTION
fix bug where when 0 entities are checked on raw signals table, the UI does not update correctly. Now the UI removes all entities and does not display a loading bar.

Resolves #192 