### PR TITLE
Display all Country Names on Hover on Home/Dashboard

### DIFF
--- a/assets/js/Ioda/components/map/Map.js
+++ b/assets/js/Ioda/components/map/Map.js
@@ -57,7 +57,8 @@ class TopoMap extends Component {
     };
 
     clickFeature = (feature) => {
-        this.props.handleEntityShapeClick(feature.properties.usercode);
+        console.log(feature);
+        this.props.handleEntityShapeClick(feature);
     };
 
     render() {

--- a/assets/js/Ioda/components/map/Map.js
+++ b/assets/js/Ioda/components/map/Map.js
@@ -57,7 +57,6 @@ class TopoMap extends Component {
     };
 
     clickFeature = (feature) => {
-        console.log(feature);
         this.props.handleEntityShapeClick(feature);
     };
 

--- a/assets/js/Ioda/components/map/Map.js
+++ b/assets/js/Ioda/components/map/Map.js
@@ -19,29 +19,28 @@ class TopoMap extends Component {
     onEachFeature = (feature, layer) => {
         layer.on({
             mouseover: (e) => this.mouseOverFeature(e, feature),
-            mouseout: (e) => this.mouseOutFeature(e)
+            mouseout: (e) => this.mouseOutFeature(e),
+            click: (e) => this.clickFeature(e, feature)
         });
     };
 
     mouseOverFeature = (e, feature) => {
-        if (feature.properties.score > 0) {
-            this.setState({
-                hoverName: feature.properties.name,
-                hoverScore: humanizeNumber(feature.properties.score),
-                hoverTooltipDisplay: true
-            }, () => {
-                if (e.target.options && e.target.options.fillColor) {
-                    let hoverColor = shadeColor(e.target.options.fillColor, -10);
-                    e.target.setStyle({
-                        fillColor: hoverColor,
-                        color: '#fff',
-                        fillOpacity: 0.4,
-                        weight: 3,
-                        dashArray: '2'
-                    });
-                }
-            })
-        }
+        this.setState({
+            hoverName: feature.properties.name,
+            hoverScore: humanizeNumber(feature.properties.score),
+            hoverTooltipDisplay: true
+        }, () => {
+            if (e.target.options && e.target.options.fillColor) {
+                let hoverColor = shadeColor(e.target.options.fillColor, -10);
+                e.target.setStyle({
+                    fillColor: hoverColor,
+                    color: '#fff',
+                    fillOpacity: 0.4,
+                    weight: 3,
+                    dashArray: '2'
+                });
+            }
+        })
     };
 
     mouseOutFeature = (e) => {
@@ -55,7 +54,12 @@ class TopoMap extends Component {
             hoverScore: 0,
             hoverTooltipDisplay: false
         })
-    }
+    };
+
+    clickFeature = (e, feature) => {
+      console.log(feature.properties.usercode);
+        this.props.handleEntityClick(feature.properties.usercode);
+    };
 
 
     render() {
@@ -70,7 +74,7 @@ class TopoMap extends Component {
         return (
             <div style={{position: 'relative', height: 'inherit', width: '100%'}}>
                 <div className={this.state.hoverTooltipDisplay ? "tooltip tooltip--visible" : "tooltip"}>
-                    <p>{this.state.hoverName} - {this.state.hoverScore}</p>
+                    <p>{this.state.hoverName}{this.state.hoverScore > 0 ? ` - ${this.state.hoverScore}`: null}</p>
                 </div>
                 <Map
                     center={this.props.bounds ? null : position}

--- a/assets/js/Ioda/components/map/Map.js
+++ b/assets/js/Ioda/components/map/Map.js
@@ -20,7 +20,7 @@ class TopoMap extends Component {
         layer.on({
             mouseover: (e) => this.mouseOverFeature(e, feature),
             mouseout: (e) => this.mouseOutFeature(e),
-            click: (e) => this.clickFeature(e, feature)
+            click: () => this.clickFeature(feature)
         });
     };
 
@@ -56,11 +56,9 @@ class TopoMap extends Component {
         })
     };
 
-    clickFeature = (e, feature) => {
-      console.log(feature.properties.usercode);
-        this.props.handleEntityClick(feature.properties.usercode);
+    clickFeature = (feature) => {
+        this.props.handleEntityShapeClick(feature.properties.usercode);
     };
-
 
     render() {
         let { scores } = this.props;

--- a/assets/js/Ioda/constants/strings/en/app.json
+++ b/assets/js/Ioda/constants/strings/en/app.json
@@ -73,7 +73,7 @@
     "regionTitle": "Regional Raw Signals related to ",
     "regionalTableTitle": "Regional Raw Signals",
     "regionalMapTitle": "Map of Regional Outages",
-    "noOutagesOnMapMessage": "No Outages to display",
+    "noOutagesOnMapMessage": "No Regional Outages Detected",
     "checkMaxButton": "Check Max (150)",
     "uncheckAllButton": "Uncheck All",
     "loadRemainingEntities1": "Number of",

--- a/assets/js/Ioda/pages/dashboard/Dashboard.js
+++ b/assets/js/Ioda/pages/dashboard/Dashboard.js
@@ -80,6 +80,7 @@ class Dashboard extends Component {
         this.regionTab = T.translate("dashboard.regionTabTitle");
         this.asTab = T.translate("dashboard.asnTabTitle");
         this.handleTimeFrame = this.handleTimeFrame.bind(this);
+        this.handleEntityClick = this.handleEntityClick.bind(this);
         this.apiQueryLimit = 170;
     }
 
@@ -192,14 +193,7 @@ class Dashboard extends Component {
             this.setState(prevState => ({
                 eventDataRaw: [...prevState.eventDataRaw, newEventData]
             }), () => {
-                console.log(this.state.eventDataRaw);
                 this.convertValuesForHtsViz();
-
-                // Use summary entities to populate time series chart
-                // const result = this.state.eventDataRaw;
-                // if (Object.keys(result).length === this.state.summaryDataRaw.length) {
-                //     this.convertValuesForHtsViz();
-                // }
             });
         }
     }
@@ -355,7 +349,7 @@ class Dashboard extends Component {
                     });
                 }
             });
-            return <TopoMap topoData={topoData} scores={scores}/>;
+            return <TopoMap topoData={topoData} scores={scores} handleEntityClick={this.handleEntityClick}/>;
         }
 
     }
@@ -364,6 +358,15 @@ class Dashboard extends Component {
         if (this.state.mounted) {
             this.props.getTopoAction(entityType);
         }
+    }
+    // function to manage when a user clicks a country in the map
+    handleEntityClick(entity) {
+        const { history } = this.props;
+        history.push(
+            window.location.search.split("?")[1]
+                ? `/country/${entity}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                : `/country/${entity}`
+        );
     }
 
 // Event Time Series

--- a/assets/js/Ioda/pages/dashboard/Dashboard.js
+++ b/assets/js/Ioda/pages/dashboard/Dashboard.js
@@ -362,11 +362,17 @@ class Dashboard extends Component {
     // function to manage when a user clicks a country in the map
     handleEntityShapeClick(entity) {
         const { history } = this.props;
-        history.push(
+        this.state.tabCurrentView === 'country'
+            ? history.push(
             window.location.search.split("?")[1]
-                ? `/country/${entity}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
-                : `/country/${entity}`
-        );
+                ? `/country/${entity.properties.usercode}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                : `/country/${entity.properties.usercode}`
+            ) :
+            history.push(
+                window.location.search.split("?")[1]
+                    ? `/region/${entity.properties.id}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                    : `/region/${entity.properties.id}`
+            )
     }
 
 // Event Time Series

--- a/assets/js/Ioda/pages/dashboard/Dashboard.js
+++ b/assets/js/Ioda/pages/dashboard/Dashboard.js
@@ -80,7 +80,7 @@ class Dashboard extends Component {
         this.regionTab = T.translate("dashboard.regionTabTitle");
         this.asTab = T.translate("dashboard.asnTabTitle");
         this.handleTimeFrame = this.handleTimeFrame.bind(this);
-        this.handleEntityClick = this.handleEntityClick.bind(this);
+        this.handleEntityShapeClick = this.handleEntityShapeClick.bind(this);
         this.apiQueryLimit = 170;
     }
 
@@ -349,7 +349,7 @@ class Dashboard extends Component {
                     });
                 }
             });
-            return <TopoMap topoData={topoData} scores={scores} handleEntityClick={this.handleEntityClick}/>;
+            return <TopoMap topoData={topoData} scores={scores} handleEntityShapeClick={this.handleEntityShapeClick}/>;
         }
 
     }
@@ -360,7 +360,7 @@ class Dashboard extends Component {
         }
     }
     // function to manage when a user clicks a country in the map
-    handleEntityClick(entity) {
+    handleEntityShapeClick(entity) {
         const { history } = this.props;
         history.push(
             window.location.search.split("?")[1]

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -984,7 +984,6 @@ class Entity extends Component {
                 let topoItemIndex = this.state.topoData.features.findIndex(topoItem => topoItem.properties.name === outage.entity.name);
 
                 if (topoItemIndex > 0) {
-                    console.log(outage);
                     let item = topoData.features[topoItemIndex];
                     item.properties.score = outage.scores.overall;
                     topoData.features[topoItemIndex] = item;

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -1105,6 +1105,7 @@ class Entity extends Component {
             />
         )
     }
+    // function to manage what happens when a linked enity in the table is clicked
     handleEntityClick() {
         this.setState({
             mounted: false,
@@ -1178,7 +1179,7 @@ class Entity extends Component {
     }
 
 
-// Modal Shared
+// Modal Windows
     // Display the table in the UI if the data is available
     genSignalsTable(entityType) {
         switch (entityType) {

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -132,6 +132,7 @@ class Entity extends Component {
         };
         this.handleTimeFrame = this.handleTimeFrame.bind(this);
         this.toggleModal = this.toggleModal.bind(this);
+        this.handleEntityShapeClick = this.handleEntityShapeClick.bind(this);
         this.initialTableLimit = 300;
         this.initialHtsLimit = 100;
         this.maxHtsLimit = 150;
@@ -978,12 +979,12 @@ class Entity extends Component {
             let scores = [];
             let outageCoords;
 
-
             // get Topographic info for a country if it has outages
             this.state.summaryDataMapRaw.map(outage => {
                 let topoItemIndex = this.state.topoData.features.findIndex(topoItem => topoItem.properties.name === outage.entity.name);
 
                 if (topoItemIndex > 0) {
+                    console.log(outage);
                     let item = topoData.features[topoItemIndex];
                     item.properties.score = outage.scores.overall;
                     topoData.features[topoItemIndex] = item;
@@ -1001,10 +1002,11 @@ class Entity extends Component {
                 outageCoords = getOutageCoords(features);
             }
 
-            return <TopoMap topoData={topoData} bounds={outageCoords} scores={scores}/>;
+            return <TopoMap topoData={topoData} bounds={outageCoords} scores={scores} handleEntityShapeClick={this.handleEntityShapeClick}/>;
         } else if (this.state.summaryDataMapRaw && this.state.summaryDataMapRaw.length === 0) {
+            const noOutagesOnMapMessage = T.translate("entityModal.noOutagesOnMapMessage");
             return <div className="related__no-outages">
-                <h2 className="related__no-outages-title">No Regional Outages Detected</h2>
+                <h2 className="related__no-outages-title">{noOutagesOnMapMessage}</h2>
             </div>
         } else {
             return <Loading/>
@@ -1037,6 +1039,83 @@ class Entity extends Component {
             // console.log(entityType, relatedToEntityType, relatedToEntityCode);
             this.props.searchRelatedToMapSummary(from, until, entityType, relatedToEntityType, relatedToEntityCode, entityCode, limit, page, includeMetadata);
         }
+    }
+    // function to manage when a user clicks a country in the map
+    handleEntityShapeClick(entity) {
+        const { history } = this.props;
+        history.push(
+            window.location.search.split("?")[1]
+                ? `/region/${entity.properties.id}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                : `/region/${entity.properties.id}`
+        );
+        this.setState({
+            mounted: false,
+            entityType: window.location.pathname.split("/")[1],
+            entityCode: window.location.pathname.split("/")[2],
+            entityName: "",
+            parentEntityName: "",
+            parentEntityCode: "",
+            // Search Bar
+            suggestedSearchResults: null,
+            searchTerm: null,
+            // XY Plot Time Series states
+            xyDataOptions: null,
+            tsDataRaw: null,
+            tsDataNormalized: true,
+            tsDataDisplayOutageBands: true,
+            // Table Pagination
+            eventTablePageNumber: 0,
+            alertTablePageNumber: 0,
+            // Event/Table Data
+            currentTable: 'alert',
+            eventDataRaw: null,
+            eventDataProcessed: [],
+            alertDataRaw: null,
+            alertDataProcessed: [],
+            // relatedTo entity Map
+            topoData: null,
+            relatedToMapSummary: null,
+            // relatedTo entity Table
+            relatedToTableApiPageNumber: 0,
+            relatedToTableSummary: null,
+            relatedToTableSummaryProcessed: null,
+            relatedToTablePageNumber: 0,
+            // Modal window display status
+            showMapModal: false,
+            showTableModal: false,
+            // Signals Modal Table on Map Panel
+            regionalSignalsTableSummaryData: [],
+            regionalSignalsTableSummaryDataProcessed: [],
+            regionalSignalsTableTotalCount: 0,
+            // Signals Modal Table on Table Panel
+            asnSignalsTableSummaryData: [],
+            asnSignalsTableSummaryDataProcessed: [],
+            asnSignalsTableTotalCount: 0,
+            // Stacked Horizon Visual on Region Map Panel
+            rawRegionalSignalsRawBgp: [],
+            rawRegionalSignalsRawPingSlash24: [],
+            rawRegionalSignalsRawUcsdNt: [],
+            rawRegionalSignalsProcessedBgp: null,
+            rawRegionalSignalsProcessedPingSlash24: null,
+            rawRegionalSignalsProcessedUcsdNt: null,
+            // Stacked Horizon Visual on ASN Table Panel
+            rawAsnSignalsRawBgp: [],
+            rawAsnSignalsRawPingSlash24: [],
+            rawAsnSignalsRawUcsdNt: [],
+            rawAsnSignalsProcessedBgp: null,
+            rawAsnSignalsProcessedPingSlash24: null,
+            rawAsnSignalsProcessedUcsdNt: null,
+            rawAsnSignalsLoadedBgp: true,
+            rawAsnSignalsLoadedPingSlash24: true,
+            rawAsnSignalsLoadedUcsdNt: true,
+            rawAsnSignalsLoadAllButtonClicked: false,
+            rawRegionalSignalsLoadedBgp: true,
+            rawRegionalSignalsLoadedPingSlash24: true,
+            rawRegionalSignalsLoadedUcsdNt: true,
+            rawRegionalSignalsLoadAllButtonClicked: false,
+        }, () => {
+            this.componentDidMount();
+        });
     }
 
 // Summary Table for related ASNs

--- a/assets/js/Ioda/pages/home/Home.js
+++ b/assets/js/Ioda/pages/home/Home.js
@@ -193,8 +193,8 @@ class Home extends Component {
         const { history } = this.props;
         history.push(
             window.location.search.split("?")[1]
-                ? `/country/${entity}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
-                : `/country/${entity}`
+                ? `/country/${entity.properties.usercode}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                : `/country/${entity.properties.usercode}`
         );
     }
     // Reset searchbar with searchterm value when a selection is made, no customizations needed here.

--- a/assets/js/Ioda/pages/home/Home.js
+++ b/assets/js/Ioda/pages/home/Home.js
@@ -79,6 +79,7 @@ class Home extends Component {
             topoData: null,
             outageSummaryData: null
         };
+        this.handleEntityShapeClick = this.handleEntityShapeClick.bind(this);
     }
 
     componentDidMount() {
@@ -152,7 +153,7 @@ class Home extends Component {
                 }
             });
 
-            return <TopoMap topoData={topoData} scores={scores}/>;
+            return <TopoMap topoData={topoData} scores={scores} handleEntityShapeClick={this.handleEntityShapeClick}/>;
 
         }
     }
@@ -187,6 +188,15 @@ class Home extends Component {
         });
         history.push(`/${entity[0].type}/${entity[0].code}`);
     };
+    // function to manage when a user clicks a country in the map
+    handleEntityShapeClick(entity) {
+        const { history } = this.props;
+        history.push(
+            window.location.search.split("?")[1]
+                ? `/country/${entity}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                : `/country/${entity}`
+        );
+    }
     // Reset searchbar with searchterm value when a selection is made, no customizations needed here.
     handleQueryUpdate = (query) => {
         this.forceUpdate();


### PR DESCRIPTION
Resolves #157 

Displaying all country names on hover for the Home page and Dashboard country tab map, and all region names on entity page and Dashboard region tab map. The country-level maps link out to their country via country code, and regions use id to link to the respective region page.