### PR TITLE
Old entity data kept when changing time frame

### DIFF
--- a/assets/js/Ioda/components/table/SignalTableRow.js
+++ b/assets/js/Ioda/components/table/SignalTableRow.js
@@ -76,10 +76,12 @@ class SignalTableRow extends Component {
 
     render() {
         let overallScore = humanizeNumber(this.props.data.score, 2);
-        const entityCode = this.props.data.entityCode;
 
         const dataSourceHeading = T.translate("table.scoresTable.dataSourceHeading");
         const scoreHeading = T.translate("table.scoresTable.scoreHeading");
+
+        const entityCode = this.props.data.entityCode;
+        const entityType = this.props.data.entityType;
 
         return(
             <tr
@@ -99,10 +101,10 @@ class SignalTableRow extends Component {
                     <Link className="table__cell-link"
                           to={
                               window.location.search.split("?")[1]
-                                  ? `/${this.props.data.entityType}/${this.props.data.entityCode}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
-                                  : `/${this.props.data.entityType}/${this.props.data.entityCode}`
+                                  ? `/${entityType}/${entityCode}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                                  : `/${entityType}/${entityCode}`
                           }
-                          onClick={() => this.props.handleEntityClick()}
+                          onClick={() => this.props.handleEntityClick(this.props.data.entityType, this.props.data.entityCode)}
                     >
                         {this.props.data.name}
                     </Link>

--- a/assets/js/Ioda/components/table/SummaryTableRow.js
+++ b/assets/js/Ioda/components/table/SummaryTableRow.js
@@ -79,6 +79,8 @@ class SummaryTableRow extends Component {
         let overallScore = humanizeNumber(this.props.data.score, 2);
         const dataSourceHeading = T.translate("table.scoresTable.dataSourceHeading");
         const scoreHeading = T.translate("table.scoresTable.scoreHeading");
+        const entityCode = this.props.data.entityCode;
+        const entityType = this.props.data.entityType;
 
         return(
             <tr
@@ -98,10 +100,10 @@ class SummaryTableRow extends Component {
                     <Link className="table__cell-link"
                           to={
                               window.location.search.split("?")[1]
-                                  ? `/${this.props.data.entityType}/${this.props.data.entityCode}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
-                                  : `/${this.props.data.entityType}/${this.props.data.entityCode}`
+                                  ? `/${entityType}/${entityCode}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
+                                  : `/${entityType}/${entityCode}`
                           }
-                          onClick={() => this.props.handleEntityClick()}
+                          onClick={() => this.props.handleEntityClick(this.props.data.entityType, this.props.data.entityCode)}
                     >
                         {this.props.data.name}
                     </Link>

--- a/assets/js/Ioda/components/table/Table.js
+++ b/assets/js/Ioda/components/table/Table.js
@@ -445,7 +445,7 @@ class Table extends Component {
                                     type === "summary" && this.props.data.map(summary => {
                                         return <SummaryTableRow key={generateKeys('summary')}
                                                                 type={this.props.type} entityType={this.props.entityType}
-                                                                data={summary} handleEntityClick={() => this.props.handleEntityClick()}
+                                                                data={summary} handleEntityClick={(entityType, entityCode) => this.props.handleEntityClick(entityType, entityCode)}
                                         />
                                     })
                                 }
@@ -454,7 +454,7 @@ class Table extends Component {
                                         return <SignalTableRow key={generateKeys('signal')} type={this.props.type}
                                                                entityType={this.props.entityType} data={signal}
                                                                toggleEntityVisibilityInHtsViz={event => this.props.toggleEntityVisibilityInHtsViz(event)}
-                                                               handleEntityClick={() => this.props.handleEntityClick()}
+                                                               handleEntityClick={(entityType, entityCode) => this.props.handleEntityClick(entityType, entityCode)}
                                         />
 
                                     })

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -138,7 +138,6 @@ class Entity extends Component {
     }
 
     componentDidMount() {
-        console.log("update2");
         // Monitor screen width
         window.addEventListener("resize", this.resize.bind(this));
         this.setState({

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -130,6 +130,7 @@ class Entity extends Component {
         this.handleTimeFrame = this.handleTimeFrame.bind(this);
         this.toggleModal = this.toggleModal.bind(this);
         this.handleEntityShapeClick = this.handleEntityShapeClick.bind(this);
+        this.handleEntityClick = this.handleEntityClick.bind(this);
         this.initialTableLimit = 300;
         this.initialHtsLimit = 100;
         this.maxHtsLimit = 150;
@@ -137,6 +138,7 @@ class Entity extends Component {
     }
 
     componentDidMount() {
+        console.log("update2");
         // Monitor screen width
         window.addEventListener("resize", this.resize.bind(this));
         this.setState({
@@ -401,12 +403,17 @@ class Entity extends Component {
 // - an entity name is clicked/hit ENTER from the searchbar drop down
 // - the time range input is updated with new values
 // - an entity is clicked on from the map
-    handleStateReset(resetType, range) {
+    handleStateReset(resetType, range, entityType, entityCode) {
         switch (resetType) {
             case "newTimeFrame":
                 this.setState({
                     from: range[0],
                     until: range[1],
+                    entityType: window.location.pathname.split("/")[1],
+                    entityCode: window.location.pathname.split("/")[2],
+                    entityName: "",
+                    parentEntityName: "",
+                    parentEntityCode: "",
                     // XY Plot Time Series states
                     xyDataOptions: null,
                     tsDataRaw: null,
@@ -474,8 +481,8 @@ class Entity extends Component {
             case "newEntity":
                 this.setState({
                     mounted: false,
-                    entityType: window.location.pathname.split("/")[1],
-                    entityCode: window.location.pathname.split("/")[2],
+                    entityType: entityType,
+                    entityCode: entityCode,
                     entityName: "",
                     parentEntityName: "",
                     parentEntityCode: "",
@@ -550,7 +557,7 @@ class Entity extends Component {
         const range = dateRangeToSeconds(dateRange, timeRange);
         const { history } = this.props;
         history.push(`/${this.state.entityType}/${this.state.entityCode}?from=${range[0]}&until=${range[1]}`);
-        this.handleStateReset("newTimeFrame", range);
+        this.handleStateReset("newTimeFrame", range, null, null);
     }
 // Search bar
     // get data for search results that populate in suggested search list
@@ -575,7 +582,7 @@ class Entity extends Component {
             return result.name === query;
         });
         history.push(`/${entity[0].type}/${entity[0].code}`);
-        this.handleStateReset("newEntity", null);
+        this.handleStateReset("newEntity", null, entity[0].type, entity[0].code);
     };
     // Reset search bar with search term value when a selection is made, no customizations needed here.
     handleQueryUpdate = (query) => {
@@ -1067,7 +1074,7 @@ class Entity extends Component {
                 ? `/region/${entity.properties.id}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
                 : `/region/${entity.properties.id}`
         );
-        this.handleStateReset("newEntity", null);
+        this.handleStateReset("newEntity", null, "region", entity.properties.id);
     }
 
 // Summary Table for related ASNs
@@ -1132,13 +1139,14 @@ class Entity extends Component {
                 data={this.state.relatedToTableSummaryProcessed}
                 totalCount={this.state.relatedToTableSummaryProcessed.length}
                 entityType={this.state.entityType === "asn" ? "country" : "asn"}
-                handleEntityClick={() => this.handleEntityClick()}
+                handleEntityClick={(entityType, entityCode) => this.handleEntityClick(entityType, entityCode)}
             />
         )
     }
-    // function to manage what happens when a linked enity in the table is clicked
-    handleEntityClick() {
-        this.handleStateReset("newEntity", null);
+    // function to manage what happens when a linked entity in the table is clicked
+    handleEntityClick(entityType, entityCode) {
+        console.log(entityType, entityCode);
+        this.handleStateReset("newEntity", null, entityType, entityCode);
     }
 
 
@@ -1154,7 +1162,7 @@ class Entity extends Component {
                         data={this.state.regionalSignalsTableSummaryDataProcessed}
                         totalCount={this.state.regionalSignalsTableSummaryDataProcessed.length}
                         toggleEntityVisibilityInHtsViz={event => this.toggleEntityVisibilityInHtsViz(event, "region")}
-                        handleEntityClick={() => this.handleEntityClick()}
+                        handleEntityClick={(entityType, entityCode) => this.handleEntityClick(entityType, entityCode)}
                     />
                 );
             case "asn":
@@ -1166,7 +1174,7 @@ class Entity extends Component {
                         totalCount={this.state.asnSignalsTableTotalCount}
                         entityType={this.state.entityType === "asn" ? "country" : "asn"}
                         toggleEntityVisibilityInHtsViz={event => this.toggleEntityVisibilityInHtsViz(event, "asn")}
-                        handleEntityClick={() => this.handleEntityClick()}
+                        handleEntityClick={(entityType, entityCode) => this.handleEntityClick(entityType, entityCode)}
                     />
                 );
         }

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -74,9 +74,6 @@ class Entity extends Component {
             tsDataNormalized: true,
             tsDataDisplayOutageBands: true,
             tsDataScreenBelow760: false,
-            // Table Pagination
-            eventTablePageNumber: 0,
-            alertTablePageNumber: 0,
             // Event/Table Data
             currentTable: 'alert',
             eventDataRaw: null,
@@ -399,71 +396,161 @@ class Entity extends Component {
         }
     }
 
+// Global reset State function, called whenever a link that's destination also uses the entity page template is used
+// - an entity name is clicked from the summary/signals table
+// - an entity name is clicked/hit ENTER from the searchbar drop down
+// - the time range input is updated with new values
+// - an entity is clicked on from the map
+    handleStateReset(resetType, range) {
+        switch (resetType) {
+            case "newTimeFrame":
+                this.setState({
+                    from: range[0],
+                    until: range[1],
+                    // XY Plot Time Series states
+                    xyDataOptions: null,
+                    tsDataRaw: null,
+                    tsDataNormalized: true,
+                    tsDataDisplayOutageBands: true,
+                    // Search Bar
+                    suggestedSearchResults: null,
+                    searchTerm: null,
+                    lastFetched: 0,
+                    // Event/Table Data
+                    currentTable: 'alert',
+                    eventDataRaw: null,
+                    eventDataProcessed: [],
+                    alertDataRaw: null,
+                    alertDataProcessed: [],
+                    // relatedTo entity Map
+                    summaryDataMapRaw: null,
+                    // relatedTo entity Table
+                    relatedToTableApiPageNumber: 0,
+                    relatedToTableSummary: null,
+                    relatedToTableSummaryProcessed: null,
+                    relatedToTablePageNumber: 0,
+                    // Modal window display status
+                    showMapModal: false,
+                    showTableModal: false,
+                    // Signals Modal Table on Map Panel
+                    regionalSignalsTableSummaryData: [],
+                    regionalSignalsTableSummaryDataProcessed: [],
+                    regionalSignalsTableTotalCount: 0,
+                    regionalSignalsTableEntitiesChecked: 0,
+                    // Signals Modal Table on Table Panel
+                    asnSignalsTableSummaryData: [],
+                    asnSignalsTableSummaryDataProcessed: [],
+                    asnSignalsTableTotalCount: 0,
+                    asnSignalsTableEntitiesChecked: 0,
+                    // Stacked Horizon Visual on Region Map Panel
+                    rawRegionalSignalsRawBgp: [],
+                    rawRegionalSignalsRawPingSlash24: [],
+                    rawRegionalSignalsRawUcsdNt: [],
+                    rawRegionalSignalsProcessedBgp: null,
+                    rawRegionalSignalsProcessedPingSlash24: null,
+                    rawRegionalSignalsProcessedUcsdNt: null,
+                    rawRegionalSignalsLoadedBgp: true,
+                    rawRegionalSignalsLoadedPingSlash24: true,
+                    rawRegionalSignalsLoadedUcsdNt: true,
+                    rawRegionalSignalsLoadAllButtonClicked: false,
+                    // Stacked Horizon Visual on ASN Table Panel
+                    rawAsnSignalsRawBgp: [],
+                    rawAsnSignalsRawPingSlash24: [],
+                    rawAsnSignalsRawUcsdNt: [],
+                    rawAsnSignalsProcessedBgp: null,
+                    rawAsnSignalsProcessedPingSlash24: null,
+                    rawAsnSignalsProcessedUcsdNt: null,
+                    rawAsnSignalsLoadAllButtonClicked: false
+                }, () => {
+                    // Get topo and outage data to repopulate map and table
+                    this.props.searchEventsAction(this.state.from, this.state.until, this.state.entityType, this.state.entityCode);
+                    this.props.searchAlertsAction(this.state.from, this.state.until, this.state.entityType, this.state.entityCode, null, null, null);
+                    this.props.getSignalsAction( this.state.entityType, this.state.entityCode, this.state.from, this.state.until, null, null);
+                    this.getDataTopo("region");
+                    this.getDataRelatedToMapSummary("region");
+                    this.getDataRelatedToTableSummary("asn");
+                });
+                break;
+            case "newEntity":
+                this.setState({
+                    mounted: false,
+                    entityType: window.location.pathname.split("/")[1],
+                    entityCode: window.location.pathname.split("/")[2],
+                    entityName: "",
+                    parentEntityName: "",
+                    parentEntityCode: "",
+                    // Search Bar
+                    suggestedSearchResults: null,
+                    searchTerm: null,
+                    lastFetched: 0,
+                    // XY Plot Time Series states
+                    xyDataOptions: null,
+                    tsDataRaw: null,
+                    tsDataNormalized: true,
+                    tsDataDisplayOutageBands: true,
+                    // Event/Table Data
+                    currentTable: 'alert',
+                    eventDataRaw: null,
+                    eventDataProcessed: [],
+                    alertDataRaw: null,
+                    alertDataProcessed: [],
+                    // relatedTo entity Map
+                    summaryDataMapRaw: null,
+                    // relatedTo entity Table
+                    relatedToTableApiPageNumber: 0,
+                    relatedToTableSummary: null,
+                    relatedToTableSummaryProcessed: null,
+                    relatedToTablePageNumber: 0,
+                    // Modal window display status
+                    showMapModal: false,
+                    showTableModal: false,
+                    // Signals Modal Table on Map Panel
+                    regionalSignalsTableSummaryData: [],
+                    regionalSignalsTableSummaryDataProcessed: [],
+                    regionalSignalsTableTotalCount: 0,
+                    // Signals Modal Table on Table Panel
+                    asnSignalsTableSummaryData: [],
+                    asnSignalsTableSummaryDataProcessed: [],
+                    asnSignalsTableTotalCount: 0,
+                    // Stacked Horizon Visual on Region Map Panel
+                    rawRegionalSignalsRawBgp: [],
+                    rawRegionalSignalsRawPingSlash24: [],
+                    rawRegionalSignalsRawUcsdNt: [],
+                    rawRegionalSignalsProcessedBgp: null,
+                    rawRegionalSignalsProcessedPingSlash24: null,
+                    rawRegionalSignalsProcessedUcsdNt: null,
+                    // Stacked Horizon Visual on ASN Table Panel
+                    rawAsnSignalsRawBgp: [],
+                    rawAsnSignalsRawPingSlash24: [],
+                    rawAsnSignalsRawUcsdNt: [],
+                    rawAsnSignalsProcessedBgp: null,
+                    rawAsnSignalsProcessedPingSlash24: null,
+                    rawAsnSignalsProcessedUcsdNt: null,
+                    rawAsnSignalsLoadedBgp: true,
+                    rawAsnSignalsLoadedPingSlash24: true,
+                    rawAsnSignalsLoadedUcsdNt: true,
+                    rawRegionalSignalsLoadedBgp: true,
+                    rawRegionalSignalsLoadedPingSlash24: true,
+                    rawRegionalSignalsLoadedUcsdNt: true,
+                    rawRegionalSignalsLoadAllButtonClicked: false,
+                    rawAsnSignalsLoadAllButtonClicked: false,
+                    rawSignalsMaxEntitiesHtsError: "",
+                    regionalRawSignalsLoadAllButtonClicked: false,
+                    asnRawSignalsLoadAllButtonClicked: false
+                }, () => {
+                    this.componentDidMount();
+                });
+                break
+        }
+    }
+
 // Control Panel
     // manage the date selected in the input
     handleTimeFrame(dateRange, timeRange) {
         const range = dateRangeToSeconds(dateRange, timeRange);
         const { history } = this.props;
         history.push(`/${this.state.entityType}/${this.state.entityCode}?from=${range[0]}&until=${range[1]}`);
-
-        this.setState({
-            from: range[0],
-            until: range[1],
-            // XY Plot Time Series states
-            xyDataOptions: null,
-            // Table Pagination
-            eventTablePageNumber: 0,
-            alertTablePageNumber: 0,
-            // Event/Table Data
-            currentTable: 'alert',
-            eventDataRaw: null,
-            eventDataProcessed: [],
-            alertDataRaw: null,
-            alertDataProcessed: [],
-            // relatedTo entity Map
-            relatedToMapSummary: null,
-            summaryDataMapRaw: null,
-            // relatedTo entity Table
-            relatedToTableApiPageNumber: 0,
-            relatedToTableSummary: null,
-            relatedToTableSummaryProcessed: null,
-            relatedToTablePageNumber: 0,
-            // Modal window display status
-            showMapModal: false,
-            showTableModal: false,
-            // Signals Modal Table on Map Panel
-            regionalSignalsTableSummaryData: [],
-            regionalSignalsTableSummaryDataProcessed: [],
-            regionalSignalsTableTotalCount: 0,
-            // Signals Modal Table on Table Panel
-            asnSignalsTableSummaryData: [],
-            asnSignalsTableSummaryDataProcessed: [],
-            asnSignalsTableTotalCount: 0,
-            // Stacked Horizon Visual on Region Map Panel
-            rawRegionalSignalsRawBgp: [],
-            rawRegionalSignalsRawPingSlash24: [],
-            rawRegionalSignalsRawUcsdNt: [],
-            rawRegionalSignalsProcessedBgp: null,
-            rawRegionalSignalsProcessedPingSlash24: null,
-            rawRegionalSignalsProcessedUcsdNt: null,
-            rawRegionalSignalsLoadAllButtonClicked: false,
-            // Stacked Horizon Visual on ASN Table Panel
-            rawAsnSignalsRawBgp: [],
-            rawAsnSignalsRawPingSlash24: [],
-            rawAsnSignalsRawUcsdNt: [],
-            rawAsnSignalsProcessedBgp: null,
-            rawAsnSignalsProcessedPingSlash24: null,
-            rawAsnSignalsProcessedUcsdNt: null,
-            rawAsnSignalsLoadAllButtonClicked: false
-        }, () => {
-            // Get topo and outage data to repopulate map and table
-            this.props.searchEventsAction(this.state.from, this.state.until, this.state.entityType, this.state.entityCode);
-            this.props.searchAlertsAction(this.state.from, this.state.until, this.state.entityType, this.state.entityCode, null, null, null);
-            this.props.getSignalsAction( this.state.entityType, this.state.entityCode, this.state.from, this.state.until, null, null);
-            this.getDataTopo("region");
-            this.getDataRelatedToMapSummary("region");
-            this.getDataRelatedToTableSummary("asn");
-        })
+        this.handleStateReset("newTimeFrame", range);
     }
 // Search bar
     // get data for search results that populate in suggested search list
@@ -488,74 +575,7 @@ class Entity extends Component {
             return result.name === query;
         });
         history.push(`/${entity[0].type}/${entity[0].code}`);
-        this.setState({
-            mounted: false,
-            entityType: window.location.pathname.split("/")[1],
-            entityCode: window.location.pathname.split("/")[2],
-            entityName: "",
-            parentEntityName: "",
-            parentEntityCode: "",
-            // Search Bar
-            suggestedSearchResults: null,
-            searchTerm: null,
-            // XY Plot Time Series states
-            xyDataOptions: null,
-            tsDataRaw: null,
-            tsDataNormalized: true,
-            tsDataDisplayOutageBands: true,
-            // Table Pagination
-            eventTablePageNumber: 0,
-            alertTablePageNumber: 0,
-            // Event/Table Data
-            currentTable: 'alert',
-            eventDataRaw: null,
-            eventDataProcessed: [],
-            alertDataRaw: null,
-            alertDataProcessed: [],
-            // relatedTo entity Map
-            topoData: null,
-            relatedToMapSummary: null,
-            // relatedTo entity Table
-            relatedToTableApiPageNumber: 0,
-            relatedToTableSummary: null,
-            relatedToTableSummaryProcessed: null,
-            relatedToTablePageNumber: 0,
-            // Modal window display status
-            showMapModal: false,
-            showTableModal: false,
-            // Signals Modal Table on Map Panel
-            regionalSignalsTableSummaryData: [],
-            regionalSignalsTableSummaryDataProcessed: [],
-            regionalSignalsTableTotalCount: 0,
-            // Signals Modal Table on Table Panel
-            asnSignalsTableSummaryData: [],
-            asnSignalsTableSummaryDataProcessed: [],
-            asnSignalsTableTotalCount: 0,
-            // Stacked Horizon Visual on Region Map Panel
-            rawRegionalSignalsRawBgp: [],
-            rawRegionalSignalsRawPingSlash24: [],
-            rawRegionalSignalsRawUcsdNt: [],
-            rawRegionalSignalsProcessedBgp: null,
-            rawRegionalSignalsProcessedPingSlash24: null,
-            rawRegionalSignalsProcessedUcsdNt: null,
-            // Stacked Horizon Visual on ASN Table Panel
-            rawAsnSignalsRawBgp: [],
-            rawAsnSignalsRawPingSlash24: [],
-            rawAsnSignalsRawUcsdNt: [],
-            rawAsnSignalsProcessedBgp: null,
-            rawAsnSignalsProcessedPingSlash24: null,
-            rawAsnSignalsProcessedUcsdNt: null,
-            rawAsnSignalsLoadedBgp: true,
-            rawAsnSignalsLoadedPingSlash24: true,
-            rawAsnSignalsLoadedUcsdNt: true,
-            rawAsnSignalsLoadAllButtonClicked: false,
-            rawRegionalSignalsLoadedBgp: true,
-            rawRegionalSignalsLoadedPingSlash24: true,
-            rawRegionalSignalsLoadedUcsdNt: true,
-            rawRegionalSignalsLoadAllButtonClicked: false,
-        }, () => {
-            this.componentDidMount();
-        });
+        this.handleStateReset("newEntity", null);
     };
     // Reset search bar with search term value when a selection is made, no customizations needed here.
     handleQueryUpdate = (query) => {
@@ -1047,74 +1067,7 @@ class Entity extends Component {
                 ? `/region/${entity.properties.id}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
                 : `/region/${entity.properties.id}`
         );
-        this.setState({
-            mounted: false,
-            entityType: window.location.pathname.split("/")[1],
-            entityCode: window.location.pathname.split("/")[2],
-            entityName: "",
-            parentEntityName: "",
-            parentEntityCode: "",
-            // Search Bar
-            suggestedSearchResults: null,
-            searchTerm: null,
-            // XY Plot Time Series states
-            xyDataOptions: null,
-            tsDataRaw: null,
-            tsDataNormalized: true,
-            tsDataDisplayOutageBands: true,
-            // Table Pagination
-            eventTablePageNumber: 0,
-            alertTablePageNumber: 0,
-            // Event/Table Data
-            currentTable: 'alert',
-            eventDataRaw: null,
-            eventDataProcessed: [],
-            alertDataRaw: null,
-            alertDataProcessed: [],
-            // relatedTo entity Map
-            topoData: null,
-            relatedToMapSummary: null,
-            // relatedTo entity Table
-            relatedToTableApiPageNumber: 0,
-            relatedToTableSummary: null,
-            relatedToTableSummaryProcessed: null,
-            relatedToTablePageNumber: 0,
-            // Modal window display status
-            showMapModal: false,
-            showTableModal: false,
-            // Signals Modal Table on Map Panel
-            regionalSignalsTableSummaryData: [],
-            regionalSignalsTableSummaryDataProcessed: [],
-            regionalSignalsTableTotalCount: 0,
-            // Signals Modal Table on Table Panel
-            asnSignalsTableSummaryData: [],
-            asnSignalsTableSummaryDataProcessed: [],
-            asnSignalsTableTotalCount: 0,
-            // Stacked Horizon Visual on Region Map Panel
-            rawRegionalSignalsRawBgp: [],
-            rawRegionalSignalsRawPingSlash24: [],
-            rawRegionalSignalsRawUcsdNt: [],
-            rawRegionalSignalsProcessedBgp: null,
-            rawRegionalSignalsProcessedPingSlash24: null,
-            rawRegionalSignalsProcessedUcsdNt: null,
-            // Stacked Horizon Visual on ASN Table Panel
-            rawAsnSignalsRawBgp: [],
-            rawAsnSignalsRawPingSlash24: [],
-            rawAsnSignalsRawUcsdNt: [],
-            rawAsnSignalsProcessedBgp: null,
-            rawAsnSignalsProcessedPingSlash24: null,
-            rawAsnSignalsProcessedUcsdNt: null,
-            rawAsnSignalsLoadedBgp: true,
-            rawAsnSignalsLoadedPingSlash24: true,
-            rawAsnSignalsLoadedUcsdNt: true,
-            rawAsnSignalsLoadAllButtonClicked: false,
-            rawRegionalSignalsLoadedBgp: true,
-            rawRegionalSignalsLoadedPingSlash24: true,
-            rawRegionalSignalsLoadedUcsdNt: true,
-            rawRegionalSignalsLoadAllButtonClicked: false,
-        }, () => {
-            this.componentDidMount();
-        });
+        this.handleStateReset("newEntity", null);
     }
 
 // Summary Table for related ASNs
@@ -1185,75 +1138,7 @@ class Entity extends Component {
     }
     // function to manage what happens when a linked enity in the table is clicked
     handleEntityClick() {
-        this.setState({
-            mounted: false,
-            entityType: window.location.pathname.split("/")[1],
-            entityCode: window.location.pathname.split("/")[2],
-            entityName: "",
-            parentEntityName: "",
-            parentEntityCode: "",
-            // Search Bar
-            suggestedSearchResults: null,
-            searchTerm: null,
-            lastFetched: 0,
-            // XY Plot Time Series states
-            xyDataOptions: null,
-            tsDataRaw: null,
-            tsDataNormalized: true,
-            tsDataDisplayOutageBands: true,
-            // Table Pagination
-            eventTablePageNumber: 0,
-            alertTablePageNumber: 0,
-            // Event/Table Data
-            currentTable: 'alert',
-            eventDataRaw: null,
-            eventDataProcessed: [],
-            alertDataRaw: null,
-            alertDataProcessed: [],
-            // relatedTo entity Map
-            topoData: null,
-            relatedToMapSummary: null,
-            // relatedTo entity Table
-            relatedToTableApiPageNumber: 0,
-            relatedToTableSummary: null,
-            relatedToTableSummaryProcessed: null,
-            relatedToTablePageNumber: 0,
-            // Modal window display status
-            showMapModal: false,
-            showTableModal: false,
-            // Signals Modal Table on Map Panel
-            regionalSignalsTableSummaryData: [],
-            regionalSignalsTableSummaryDataProcessed: [],
-            regionalSignalsTableTotalCount: 0,
-            // Signals Modal Table on Table Panel
-            asnSignalsTableSummaryData: [],
-            asnSignalsTableSummaryDataProcessed: [],
-            asnSignalsTableTotalCount: 0,
-            // Stacked Horizon Visual on Region Map Panel
-            rawRegionalSignalsRawBgp: [],
-            rawRegionalSignalsRawPingSlash24: [],
-            rawRegionalSignalsRawUcsdNt: [],
-            rawRegionalSignalsProcessedBgp: null,
-            rawRegionalSignalsProcessedPingSlash24: null,
-            rawRegionalSignalsProcessedUcsdNt: null,
-            // Stacked Horizon Visual on ASN Table Panel
-            rawAsnSignalsRawBgp: [],
-            rawAsnSignalsRawPingSlash24: [],
-            rawAsnSignalsRawUcsdNt: [],
-            rawAsnSignalsProcessedBgp: null,
-            rawAsnSignalsProcessedPingSlash24: null,
-            rawAsnSignalsProcessedUcsdNt: null,
-            rawAsnSignalsLoadedBgp: true,
-            rawAsnSignalsLoadedPingSlash24: true,
-            rawAsnSignalsLoadedUcsdNt: true,
-            rawRegionalSignalsLoadedBgp: true,
-            rawRegionalSignalsLoadedPingSlash24: true,
-            rawRegionalSignalsLoadedUcsdNt: true,
-            rawRegionalSignalsLoadAllButtonClicked: false,
-            rawAsnSignalsLoadAllButtonClicked: false,
-        }, () => {
-            this.componentDidMount();
-        });
+        this.handleStateReset("newEntity", null);
     }
 
 


### PR DESCRIPTION
Resolves #184 

Clicking on an entity from a table, then changing the timeframe no longer persists old data, entityCode and entityType are updated every time a new entity is loaded from one of the various methods of changing entities while on the entity page.