### PR TITLE
Update regional panel title to reflect that it's perspective is from a region

### DIFF
--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -408,11 +408,6 @@ class Entity extends Component {
                 this.setState({
                     from: range[0],
                     until: range[1],
-                    entityType: window.location.pathname.split("/")[1],
-                    entityCode: window.location.pathname.split("/")[2],
-                    entityName: "",
-                    parentEntityName: "",
-                    parentEntityCode: "",
                     // XY Plot Time Series states
                     xyDataOptions: null,
                     tsDataRaw: null,


### PR DESCRIPTION
Resolves #182 

updated state update when timeframe changes, this was causing the entity name to be updated incorrectly in memory