### PR TITLE
[XY Plot Time Series] - Various Fixes

### DIFF
--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -614,6 +614,8 @@ class Entity extends Component {
             networkTelescope = {
                 type: "line",
                 lineThickness: 1,
+                color: "#E31A1C",
+                lineColor: "#E31A1C",
                 markerType: "circle",
                 markerSize: 2,
                 name: "Network Telescope",
@@ -622,6 +624,7 @@ class Entity extends Component {
                 xValueFormatString: "DDD, MMM DD - HH:MM",
                 yValueFormatString: "##",
                 dataPoints: networkTelescopeValues,
+                legendMarkerColor: "#E31A1C",
                 toolTipContent: "{x} <br/> Network Telescope (# Unique Source IPs): {y}"
             }
         }
@@ -629,6 +632,8 @@ class Entity extends Component {
             bgp = {
                 type: "line",
                 lineThickness: 1,
+                color: "#33A02C",
+                lineColor: "#33A02C",
                 markerType: "circle",
                 markerSize: 2,
                 name: "BGP",
@@ -636,6 +641,7 @@ class Entity extends Component {
                 xValueFormatString: "DDD, MMM DD - HH:MM",
                 yValueFormatString: "##",
                 dataPoints: bgpValues,
+                legendMarkerColor: "#33A02C",
                 toolTipContent: "{x} <br/> BGP (# Visbile /24s): {y}"
             }
         }
@@ -644,6 +650,8 @@ class Entity extends Component {
             activeProbing = {
                 type: "line",
                 lineThickness: 1,
+                color: "#1F78B4",
+                lineColor: "#1F78B4",
                 markerType: "circle",
                 markerSize: 2,
                 name: "Active Probing",
@@ -651,7 +659,9 @@ class Entity extends Component {
                 xValueFormatString: "DDD, MMM DD - HH:MM",
                 yValueFormatString: "##",
                 dataPoints: activeProbingValues,
-                toolTipContent: "{x} <br/> Active Probing (# /24s Up): {y}"
+                legendMarkerColor: "#1F78B4",
+                toolTipContent: "{x} <br/> Active Probing (# /24s Up): {y}",
+
             }
         }
 
@@ -675,7 +685,7 @@ class Entity extends Component {
                         let x, y;
                         x = toDateTime(datasource.from + (datasource.step * index));
                         y = this.state.tsDataNormalized ? normalize(value, min, max) : value;
-                        networkTelescopeValues.push({x: x, y: y});
+                        networkTelescopeValues.push({x: x, y: y, color: "#E31A1C"});
                     });
                     break;
                 case "bgp":
@@ -686,7 +696,7 @@ class Entity extends Component {
                         let x, y;
                         x = toDateTime(datasource.from + (datasource.step * index));
                         y = this.state.tsDataNormalized ? normalize(value, min, max) : value;
-                        bgpValues.push({x: x, y: y});
+                        bgpValues.push({x: x, y: y, color: "#33A02C"});
                     });
                     break;
                 case "ping-slash24":
@@ -697,7 +707,7 @@ class Entity extends Component {
                         let x, y;
                         x = toDateTime(datasource.from + (datasource.step * index));
                         y = this.state.tsDataNormalized ? normalize(value, min, max) : value;
-                        activeProbingValues.push({x: x, y: y});
+                        activeProbingValues.push({x: x, y: y, color: "#1F78B4"});
                     });
             }
         });
@@ -736,19 +746,15 @@ class Entity extends Component {
                 axisY: {
                     // title: "Active Probing and BGP",
                     titleFontsColor: "#666666",
-                    lineColor: "#34a02c",
                     labelFontColor: "#666666",
-                    tickColor: "#34a02c",
                     labelFontSize: 12,
-                    maximum: this.state.tsDataNormalized ? 100 : null
+                    maximum: this.state.tsDataNormalized ? 105 : null
                 },
                 axisY2: {
                     // title: "Network Telescope",
                     titleFontsColor: "#666666",
-                    lineColor: "#00a9e0",
                     labelFontColor: "#666666",
-                    tickColor: "#00a9e0",
-                    labelFontSize: 12,
+                    labelFontSize: 12
                 },
                 toolTip: {
                     shared: false,

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -726,6 +726,18 @@ class Entity extends Component {
             });
         }
 
+        // get time span considered, using network telescope first as that data source has the most up to time data, then Ping-slash24, then bgp
+        const timeBegin = networkTelescopeValues[0].x;
+        const timeEnd = networkTelescopeValues[networkTelescopeValues.length -1].x;
+        // Add 5% padding to the right edge of the Chart
+        const extraPadding = (timeEnd - timeBegin) * 0.05;
+        const viewportMaximum = new Date(timeEnd.getTime() + extraPadding);
+
+        activeProbingValues.push({x: viewportMaximum, y: null});
+        bgpValues.push({x: viewportMaximum, y: null});
+        networkTelescopeValues.push({x: viewportMaximum, y: null});
+
+
         this.setState({
             xyDataOptions: {
                 theme: "light2",

--- a/assets/js/Ioda/utils/index.js
+++ b/assets/js/Ioda/utils/index.js
@@ -327,5 +327,5 @@ export function dateRangeToSeconds(dateRange, timeRange) {
 
 // Normalize valye in XY plot of time series on entity page
 export function normalize(value, min, max) {
-    return (value - min) / (max - min) * 100;
+    return value !== null ? (value - min) / (max - min) * 100 : null;
 }


### PR DESCRIPTION
Resolves #187 correcting the following issues - 

- zoom misbehaves when dragging beyond end of graph
- lines are showing points also when data is NULL/missing (e.g., towards the end of the graph). It only happens at the normalized graph
-  colors of each of IBR, BGP, AP should always be the same: red for IBR, green for BGP, blue for AP
-  buttons for zoom overlap over data displayed on visual. It should be above so that the data isn’t hidden underneath the buttons.

