### PR TITLE
removed visibility of time series that have no score 

### DIFF
--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -1532,9 +1532,9 @@ class Entity extends Component {
                 .enableZoom(false)
                 .showRuler(true)
                 .interpolationCurve(d3.curveStepAfter)
-                .positiveColors(['white', '#6190B5'])
-                // .positiveColorStops([.99])
-                .toolTipContent = ({series, ts, val}) => `${series}<br>${ts}: ${humanizeNumber(val)}`;
+                .positiveColors(['white', '#006D2D'])
+                // .positiveColorStops([.01])
+                .toolTipContent = ({series, ts, val}) => `${series}<br>${ts}:&nbsp;${val !== 0 ? humanizeNumber(val) : "n/a"}`;
         }
     }
     // function to manage what happens when a checkbox is changed in the raw signals table

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -1534,7 +1534,7 @@ class Entity extends Component {
                 .interpolationCurve(d3.curveStepAfter)
                 .positiveColors(['white', '#006D2D'])
                 // .positiveColorStops([.01])
-                .toolTipContent = ({series, ts, val}) => `${series}<br>${ts}:&nbsp;${val !== 0 ? humanizeNumber(val) : "n/a"}`;
+                .toolTipContent = ({series, ts, val}) => `${series}<br>${ts}:&nbsp;${humanizeNumber(val)}`;
         }
     }
     // function to manage what happens when a checkbox is changed in the raw signals table

--- a/assets/js/Ioda/utils/index.js
+++ b/assets/js/Ioda/utils/index.js
@@ -254,7 +254,9 @@ export function sortByKey(array, key) {
 export function convertTsDataForHtsViz(tsData) {
     let series = [];
     tsData.map(signal => {
+        let values = [];
         signal.values.map((value, index) => {
+            values.push(value);
             const plotPoint = {
                 entityCode: signal.entityCode,
                 entityName: signal.entityName,
@@ -262,7 +264,10 @@ export function convertTsDataForHtsViz(tsData) {
                 ts: new Date(signal.from * 1000 + signal.step * 1000 * index),
                 val: value
             };
-            series.push(plotPoint);
+            const max = Math.max( ...values );
+            if (max !== 0) {
+                series.push(plotPoint);
+            }
         });
     });
     return series;


### PR DESCRIPTION
Resolves #124 

instead of taking up space and populating 0, which renders as a full bar instead of empty, series that have a consistent score of 0 in the provided time span are no longer rendered. This mimics the behavior identified in v1 where signals do not display if there is nothing notable to display in the raw signals horizon time series.