### PR TITLE
current count of series displayed in horizon time series does not reset after closing the modal

### DIFF
--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -530,10 +530,12 @@ class Entity extends Component {
                     regionalSignalsTableSummaryData: [],
                     regionalSignalsTableSummaryDataProcessed: [],
                     regionalSignalsTableTotalCount: 0,
+                    regionalSignalsTableEntitiesChecked: 0,
                     // Signals Modal Table on Table Panel
                     asnSignalsTableSummaryData: [],
                     asnSignalsTableSummaryDataProcessed: [],
                     asnSignalsTableTotalCount: 0,
+                    asnSignalsTableEntitiesChecked: 0,
                     // Stacked Horizon Visual on Region Map Panel
                     rawRegionalSignalsRawBgp: [],
                     rawRegionalSignalsRawPingSlash24: [],


### PR DESCRIPTION
Resolves #245 

When going to an entity page and opening a modal, then changing entities to a new page, the prior value of currently displayed series in the horizon time series visual now initially displays at 0.