### PR TITLE
Typing a dashboard tab url into the searchbar defaults to the country tab, lock map zoom on mouse scroll

### DIFF
--- a/assets/js/Ioda/components/map/Map.js
+++ b/assets/js/Ioda/components/map/Map.js
@@ -74,6 +74,7 @@ class TopoMap extends Component {
                     zoom={this.props.bounds ? null : zoom}
                     bounds={this.props.bounds ? this.props.bounds : null}
                     minZoom={1}
+                    scrollWheelZoom={false}
                     style={{width: 'inherit', height: 'inherit', overflow: 'hidden'}}
                 >
                     <TileLayer

--- a/assets/js/Ioda/pages/dashboard/Dashboard.js
+++ b/assets/js/Ioda/pages/dashboard/Dashboard.js
@@ -49,8 +49,8 @@ class Dashboard extends Component {
                 window.location.pathname.split("/")[2].split("?")[0] === asn.type ? asn.tab : country.tab,
             activeTabType: window.location.pathname.split("/")[2].split("?")[0] === region.type ? region.type :
                 window.location.pathname.split("/")[2].split("?")[0] === asn.type ? asn.type : country.type,
-            tab: window.location.pathname.split("/")[2].split("?")[0] === "region" ? "Region View" :
-                window.location.pathname.split("/")[2].split("?")[0] === "asn" ? "ASN View" : "Country View",
+            tab: window.location.pathname.split("/")[2].split("?")[0] === "region" ? T.translate("dashboard.regionTabTitle") :
+                window.location.pathname.split("/")[2].split("?")[0] === "asn" ? T.translate("dashboard.asnTabTitle") : T.translate("dashboard.countryTabTitle"),
             //Tab View Changer Button
             tabCurrentView: window.location.pathname.split("/")[2].split("?")[0] === asn.type ? 'timeSeries' : "map",
             // Search Bar
@@ -86,10 +86,6 @@ class Dashboard extends Component {
     }
 
     componentDidMount() {
-        console.log("update24");
-        console.log(window.location.pathname.split("/")[2].split("?")[0]);
-
-
         // Check if time parameters are provided
         let timeEntryInUrl = window.location.pathname.split("?");
         if (timeEntryInUrl[1]){

--- a/assets/js/Ioda/pages/dashboard/DashboardConstants.js
+++ b/assets/js/Ioda/pages/dashboard/DashboardConstants.js
@@ -15,10 +15,10 @@ const region = {
     tab: 2,
     url: '/dashboard/region'
 };
-const as = {
+const asn = {
     type: 'asn',
     tab: 3,
-    url: '/dashboard/as'
+    url: '/dashboard/asn'
 };
 
-export {tabOptions, country, region, as};
+export {tabOptions, country, region, asn};


### PR DESCRIPTION
Resolves #266 and #267

Now links like https://dev.v2.ioda.caida.org/dashboard/region and /asn/?from=1623279030&until=1623451830 will work, allowing for easier url reference on the dashboard with being able to specify a particular entity type. Both http://localhost:8000/dashboard/country/?from=1623279030&until=1623451830 and http://localhost:8000/dashboard/?from=1623279030&until=1623451830 work, defaulting to the country entity.

Map zoom is also disabled on mouse scroll as well, matching v1. Scrolling down a page and then inadvertently scrolling on the map  