### PR TITLE
update signals api to only allow 3000 datapoints max

### DIFF
--- a/assets/js/Ioda/data/ActionSignals.js
+++ b/assets/js/Ioda/data/ActionSignals.js
@@ -49,8 +49,8 @@ import {
     GET_ADDITIONAL_RAW_SIGNAL
 } from "./ActionCommons";
 
-const buildSignalsConfig = (entityType, entityCode, from, until, datasource, maxPoints=null) => {
-    let url = `/signals/raw/${entityType}/${entityCode}?from=${from}&until=${until}`;
+const buildSignalsConfig = (entityType, entityCode, from, until, datasource, maxPoints) => {
+    let url = `/signals/raw/${entityType}/${entityCode}?from=${from}&until=${until}&maxPoints=${maxPoints}`;
     url += datasource!==null ? `&datasource=${datasource}`: "";
     return {
         method: "get",
@@ -71,7 +71,7 @@ const buildEventSignalsConfig = (entityType, entityCode, from, until, datasource
 PUBLIC ACTION FUNCTIONS
  */
 
-export const getSignalsAction = (dispatch, entityType, entityCode, from, until, datasource=null, maxPoints=null) => {
+export const getSignalsAction = (dispatch, entityType, entityCode, from, until, datasource=null, maxPoints) => {
     let config = buildSignalsConfig(entityType, entityCode, from, until, datasource, maxPoints);
     fetchData(config).then(data => {
         dispatch({

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -160,7 +160,7 @@ class Entity extends Component {
             // Overview Panel
             this.props.searchEventsAction(this.state.from, this.state.until, window.location.pathname.split("/")[1], window.location.pathname.split("/")[2]);
             this.props.searchAlertsAction(this.state.from, this.state.until, window.location.pathname.split("/")[1], window.location.pathname.split("/")[2], null, null, null);
-            this.props.getSignalsAction(window.location.pathname.split("/")[1], window.location.pathname.split("/")[2], this.state.from, this.state.until, null, null);
+            this.props.getSignalsAction(window.location.pathname.split("/")[1], window.location.pathname.split("/")[2], this.state.from, this.state.until, null, 3000);
             // Get entity name from code provided in url
             this.props.getEntityMetadataAction(window.location.pathname.split("/")[1], window.location.pathname.split("/")[2]);
         });
@@ -2062,7 +2062,7 @@ const mapDispatchToProps = (dispatch) => {
         searchAlertsAction: (from, until, entityType, entityCode, datasource=null, limit=null, page=null) => {
             searchAlerts(dispatch, from, until, entityType, entityCode, datasource, limit, page);
         },
-        getSignalsAction: (entityType, entityCode, from, until, datasource=null, maxPoints=null) => {
+        getSignalsAction: (entityType, entityCode, from, until, datasource=null, maxPoints) => {
             getSignalsAction(dispatch, entityType, entityCode, from, until, datasource, maxPoints);
         },
 


### PR DESCRIPTION
Resolves #199 

Now loading a year's worth of data is not a heavy task for the api that causes errors in chrome and safari.