### PR TITLE
add check if url back to dashboard has trailing slash in it or not, then load page as normal

### DIFF
--- a/assets/js/Ioda/components/controlPanel/ControlPanel.js
+++ b/assets/js/Ioda/components/controlPanel/ControlPanel.js
@@ -217,7 +217,7 @@ class ControlPanel extends Component {
         history.push(
             window.location.search.split("?")[1]
                 ? `/dashboard?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
-                : `/dashboard/`
+                : `/dashboard`
         );
     }
 

--- a/assets/js/Ioda/pages/dashboard/Dashboard.js
+++ b/assets/js/Ioda/pages/dashboard/Dashboard.js
@@ -101,8 +101,14 @@ class Dashboard extends Component {
         },() => {
             // Set initial tab to load
             this.handleSelectTab(this.tabs[this.props.match.params.tab]);
+
             // Get topo and outage data to populate map and table
-            window.location.pathname.split("/")[2] && window.location.pathname.split("/")[2].split("?")[0] !== "asn" ? this.getDataTopo(this.state.activeTabType) : window.location.pathname.split("/").length === 2 ? this.getDataTopo(this.state.activeTabType) : null;
+            window.location.pathname.split("/")[2] && window.location.pathname.split("/")[2].split("?")[0] !== "asn" ?
+                this.getDataTopo(this.state.activeTabType) :
+                window.location.pathname.split("/").length === 2 ? this.getDataTopo(this.state.activeTabType) :
+                    window.location.pathname.split("/").length === 3 && window.location.pathname.split("/")[2] === "" ? this.getDataTopo(this.state.activeTabType) :
+                    null;
+
             this.getDataOutageSummary(this.state.activeTabType);
             this.getTotalOutages(this.state.activeTabType);
         });


### PR DESCRIPTION
Having a trailing slash going to /dashboard/ vs /dashboard was throwing off the process that determines which tab to initially load. The link back from the entity page was sending users to /dashboard/.

Resolves #291 